### PR TITLE
Add standing deals endpoint

### DIFF
--- a/OTS.Solution/OTS.DOMAIN/MobileAccountingVM/DealHistoryResultVM.cs
+++ b/OTS.Solution/OTS.DOMAIN/MobileAccountingVM/DealHistoryResultVM.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+namespace OTS.DOMAIN.MobileAccountingVM
+{
+    public class DealHistoryResultVM
+    {
+        public IEnumerable<DealHistoryVM> Rows { get; set; } = new List<DealHistoryVM>();
+        public int RowCount { get; set; }
+    }
+}

--- a/OTS.Solution/OTS.DOMAIN/MobileAccountingVM/DealHistoryVM.cs
+++ b/OTS.Solution/OTS.DOMAIN/MobileAccountingVM/DealHistoryVM.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace OTS.DOMAIN.MobileAccountingVM
+{
+    public class DealHistoryVM
+    {
+        public long Login { get; set; }
+        public DateTime Time { get; set; }
+        public long Deal { get; set; }
+        public string? Symbol { get; set; }
+        public string? Contype { get; set; }
+        public int Entry { get; set; }
+        public decimal Qty { get; set; }
+        public decimal Price { get; set; }
+        public decimal Volume { get; set; }
+        public decimal VolumeExt { get; set; }
+        public decimal Profit { get; set; }
+        public decimal Commission { get; set; }
+        public string? Comment { get; set; }
+    }
+}

--- a/OTS.Solution/OTS.DOMAIN/MobileAccountingVM/LiveSummaryResultVM.cs
+++ b/OTS.Solution/OTS.DOMAIN/MobileAccountingVM/LiveSummaryResultVM.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+namespace OTS.DOMAIN.MobileAccountingVM
+{
+    public class LiveSummaryResultVM
+    {
+        public IEnumerable<LiveSummaryVM> Rows { get; set; } = new List<LiveSummaryVM>();
+        public int RowCount { get; set; }
+    }
+}

--- a/OTS.Solution/OTS.DOMAIN/MobileAccountingVM/LiveSummaryVM.cs
+++ b/OTS.Solution/OTS.DOMAIN/MobileAccountingVM/LiveSummaryVM.cs
@@ -9,10 +9,21 @@ namespace OTS.DOMAIN.MobileAccountingVM
         public decimal OpenQty { get; set; }
         public decimal OpenRate { get; set; }
         public decimal OpenAmt { get; set; }
-        public decimal BuyQty { get; set; }
-        public decimal BuyAmt { get; set; }
-        public decimal SellQty { get; set; }
-        public decimal SellAmt { get; set; }
+
+        // Stored procedure returns abbreviated column names (BQty, BAmt, etc.).
+        // Map them here while preserving the expected camel‑cased JSON names.
+        [System.Text.Json.Serialization.JsonPropertyName("buyQty")]
+        public decimal BQty { get; set; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("buyAmt")]
+        public decimal BAmt { get; set; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("sellQty")]
+        public decimal SQty { get; set; }
+
+        [System.Text.Json.Serialization.JsonPropertyName("sellAmt")]
+        public decimal SAmt { get; set; }
+
         public decimal Commission { get; set; }
         public decimal CloseQty { get; set; }
         public decimal CloseRate { get; set; }

--- a/OTS.Solution/OTS.DOMAIN/MobileAccountingVM/LiveSummaryVM.cs
+++ b/OTS.Solution/OTS.DOMAIN/MobileAccountingVM/LiveSummaryVM.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace OTS.DOMAIN.MobileAccountingVM
+{
+    public class LiveSummaryVM
+    {
+        public long Login { get; set; }
+        public string? Symbol { get; set; }
+        public decimal OpenQty { get; set; }
+        public decimal OpenRate { get; set; }
+        public decimal OpenAmt { get; set; }
+        public decimal BuyQty { get; set; }
+        public decimal BuyAmt { get; set; }
+        public decimal SellQty { get; set; }
+        public decimal SellAmt { get; set; }
+        public decimal Commission { get; set; }
+        public decimal CloseQty { get; set; }
+        public decimal CloseRate { get; set; }
+        public decimal CloseAmt { get; set; }
+        public decimal GrossMTM { get; set; }
+        public decimal NetAmt { get; set; }
+    }
+}

--- a/OTS.Solution/OTS.DOMAIN/MobileAccountingVM/LiveSummaryVM.cs
+++ b/OTS.Solution/OTS.DOMAIN/MobileAccountingVM/LiveSummaryVM.cs
@@ -10,19 +10,19 @@ namespace OTS.DOMAIN.MobileAccountingVM
         public decimal OpenRate { get; set; }
         public decimal OpenAmt { get; set; }
 
-        // Stored procedure returns abbreviated column names (BQty, BAmt, etc.).
-        // Map them here while preserving the expected camel‑cased JSON names.
+        // Map database column names to camel‑cased JSON names.
+        // The stored procedure returns BuyQty/BuyAmt/SellQty/SellAmt.
         [System.Text.Json.Serialization.JsonPropertyName("buyQty")]
-        public decimal BQty { get; set; }
+        public decimal BuyQty { get; set; }
 
         [System.Text.Json.Serialization.JsonPropertyName("buyAmt")]
-        public decimal BAmt { get; set; }
+        public decimal BuyAmt { get; set; }
 
         [System.Text.Json.Serialization.JsonPropertyName("sellQty")]
-        public decimal SQty { get; set; }
+        public decimal SellQty { get; set; }
 
         [System.Text.Json.Serialization.JsonPropertyName("sellAmt")]
-        public decimal SAmt { get; set; }
+        public decimal SellAmt { get; set; }
 
         public decimal Commission { get; set; }
         public decimal CloseQty { get; set; }

--- a/OTS.Solution/OTS.DOMAIN/MobileAccountingVM/StandingResultVM.cs
+++ b/OTS.Solution/OTS.DOMAIN/MobileAccountingVM/StandingResultVM.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+namespace OTS.DOMAIN.MobileAccountingVM
+{
+    public class StandingResultVM
+    {
+        public IEnumerable<StandingVM> Rows { get; set; } = new List<StandingVM>();
+        public int RowCount { get; set; }
+    }
+}

--- a/OTS.Solution/OTS.DOMAIN/MobileAccountingVM/StandingVM.cs
+++ b/OTS.Solution/OTS.DOMAIN/MobileAccountingVM/StandingVM.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace OTS.DOMAIN.MobileAccountingVM
+{
+    public class StandingVM
+    {
+        public DateTime TradeDate { get; set; }
+        public long Login { get; set; }
+        public string? Symbol { get; set; }
+        public decimal BuyQty { get; set; }
+        public decimal SellQty { get; set; }
+    }
+}

--- a/OTS.Solution/OTS.DOMAIN/MobileAccountingVM/StandingVM.cs
+++ b/OTS.Solution/OTS.DOMAIN/MobileAccountingVM/StandingVM.cs
@@ -4,10 +4,13 @@ namespace OTS.DOMAIN.MobileAccountingVM
 {
     public class StandingVM
     {
-        public DateTime TradeDate { get; set; }
         public long Login { get; set; }
         public string? Symbol { get; set; }
+        public DateTime ExpiryDate { get; set; }
         public decimal BuyQty { get; set; }
         public decimal SellQty { get; set; }
+        public decimal NetQty { get; set; }
+        public decimal BrokerShare { get; set; }
+        public decimal ManagerShare { get; set; }
     }
 }

--- a/OTS.Solution/OTS.Infrastructutre/MobileRepository/Implementations/DealHistoryRepository.cs
+++ b/OTS.Solution/OTS.Infrastructutre/MobileRepository/Implementations/DealHistoryRepository.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Threading;
+using System.Threading.Tasks;
+using MobileAccounting.Repositories.Interfaces;
+using OTS.DOMAIN.MobileAccountingVM;
+using OTS.Infrastructutre.Generic.WebBroker.DataAccessCore;
+
+namespace MobileAccounting.Repositories.Implementations
+{
+    public class DealHistoryRepository : IDealHistoryRepository
+    {
+        private readonly DbManager _db;
+
+        public DealHistoryRepository(DbManager db)
+        {
+            _db = db;
+        }
+
+        public async Task<DealHistoryResultVM> GetDealHistoryAsync(DateTime fromDate, DateTime toDate, long? managerId, CancellationToken ct)
+        {
+            var parameters = new List<DbParameter>
+            {
+                new DbParameter("FromDate", ParameterDirection.Input, fromDate),
+                new DbParameter("ToDate", ParameterDirection.Input, toDate),
+                new DbParameter("ManagerId", ParameterDirection.Input, managerId)
+            };
+
+            var rows = await _db.ExecuteListAsync<DealHistoryVM>("usp_GetDealHistory", parameters);
+            return new DealHistoryResultVM
+            {
+                Rows = rows,
+                RowCount = rows.Count
+            };
+        }
+    }
+}

--- a/OTS.Solution/OTS.Infrastructutre/MobileRepository/Implementations/DealHistoryRepository.cs
+++ b/OTS.Solution/OTS.Infrastructutre/MobileRepository/Implementations/DealHistoryRepository.cs
@@ -18,13 +18,14 @@ namespace MobileAccounting.Repositories.Implementations
             _db = db;
         }
 
-        public async Task<DealHistoryResultVM> GetDealHistoryAsync(DateTime fromDate, DateTime toDate, long? managerId, CancellationToken ct)
+        public async Task<DealHistoryResultVM> GetDealHistoryAsync(DateTime fromDate, DateTime toDate, long? managerId, long? login, CancellationToken ct)
         {
             var parameters = new List<DbParameter>
             {
                 new DbParameter("FromDate", ParameterDirection.Input, fromDate),
                 new DbParameter("ToDate", ParameterDirection.Input, toDate),
-                new DbParameter("ManagerId", ParameterDirection.Input, managerId)
+                new DbParameter("ManagerId", ParameterDirection.Input, managerId),
+                new DbParameter("Login", ParameterDirection.Input, login)
             };
 
             var rows = await _db.ExecuteListAsync<DealHistoryVM>("usp_GetDealHistory", parameters);

--- a/OTS.Solution/OTS.Infrastructutre/MobileRepository/Implementations/LiveSummaryRepository.cs
+++ b/OTS.Solution/OTS.Infrastructutre/MobileRepository/Implementations/LiveSummaryRepository.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Threading;
+using System.Threading.Tasks;
+using MobileAccounting.Repositories.Interfaces;
+using OTS.DOMAIN.MobileAccountingVM;
+using OTS.Infrastructutre.Generic.WebBroker.DataAccessCore;
+
+namespace MobileAccounting.Repositories.Implementations
+{
+    public class LiveSummaryRepository : ILiveSummaryRepository
+    {
+        private readonly DbManager _db;
+
+        public LiveSummaryRepository(DbManager db)
+        {
+            _db = db;
+        }
+
+        public async Task<LiveSummaryResultVM> GetLiveSummaryAsync(DateTime fromDate, DateTime toDate, long? managerId, string? exchange, CancellationToken ct)
+        {
+            var parameters = new List<DbParameter>
+            {
+                new DbParameter("FromDate", ParameterDirection.Input, fromDate),
+                new DbParameter("ToDate", ParameterDirection.Input, toDate),
+                new DbParameter("ManagerId", ParameterDirection.Input, managerId),
+                new DbParameter("Exchange", ParameterDirection.Input, exchange)
+            };
+
+            var rows = await _db.ExecuteListAsync<LiveSummaryVM>("usp_GetLiveSummary", parameters);
+            return new LiveSummaryResultVM
+            {
+                Rows = rows,
+                RowCount = rows.Count
+            };
+        }
+    }
+}

--- a/OTS.Solution/OTS.Infrastructutre/MobileRepository/Implementations/LiveSummaryRepository.cs
+++ b/OTS.Solution/OTS.Infrastructutre/MobileRepository/Implementations/LiveSummaryRepository.cs
@@ -18,14 +18,15 @@ namespace MobileAccounting.Repositories.Implementations
             _db = db;
         }
 
-        public async Task<LiveSummaryResultVM> GetLiveSummaryAsync(DateTime fromDate, DateTime toDate, long? managerId, string? exchange, CancellationToken ct)
+        public async Task<LiveSummaryResultVM> GetLiveSummaryAsync(DateTime fromDate, DateTime toDate, long? managerId, string? exchange, string? option, CancellationToken ct)
         {
             var parameters = new List<DbParameter>
             {
                 new DbParameter("FromDate", ParameterDirection.Input, fromDate),
                 new DbParameter("ToDate", ParameterDirection.Input, toDate),
                 new DbParameter("ManagerId", ParameterDirection.Input, managerId),
-                new DbParameter("Exchange", ParameterDirection.Input, exchange)
+                new DbParameter("Exchange", ParameterDirection.Input, exchange),
+                new DbParameter("Option", ParameterDirection.Input, option)
             };
 
             var rows = await _db.ExecuteListAsync<LiveSummaryVM>("usp_GetLiveSummary", parameters);

--- a/OTS.Solution/OTS.Infrastructutre/MobileRepository/Implementations/StandingRepository.cs
+++ b/OTS.Solution/OTS.Infrastructutre/MobileRepository/Implementations/StandingRepository.cs
@@ -18,12 +18,11 @@ namespace MobileAccounting.Repositories.Implementations
             _db = db;
         }
 
-        public async Task<StandingResultVM> GetStandingAsync(DateOnly onDate, long? login, string? symbol, CancellationToken ct)
+        public async Task<StandingResultVM> GetStandingAsync(DateOnly onDate, string? symbol, CancellationToken ct)
         {
             var parameters = new List<DbParameter>
             {
                 new DbParameter("OnDate", ParameterDirection.Input, onDate.ToDateTime(TimeOnly.MinValue)),
-                new DbParameter("Login", ParameterDirection.Input, login),
                 new DbParameter("Symbol", ParameterDirection.Input, symbol)
             };
 

--- a/OTS.Solution/OTS.Infrastructutre/MobileRepository/Implementations/StandingRepository.cs
+++ b/OTS.Solution/OTS.Infrastructutre/MobileRepository/Implementations/StandingRepository.cs
@@ -18,13 +18,14 @@ namespace MobileAccounting.Repositories.Implementations
             _db = db;
         }
 
-        public async Task<StandingResultVM> GetStandingAsync(DateOnly onDate, long? login, string? symbol, CancellationToken ct)
+        public async Task<StandingResultVM> GetStandingAsync(DateOnly onDate, long? login, string? symbol, string? option, CancellationToken ct)
         {
             var parameters = new List<DbParameter>
             {
                 new DbParameter("OnDate", ParameterDirection.Input, onDate.ToDateTime(TimeOnly.MinValue)),
                 new DbParameter("Login", ParameterDirection.Input, login),
-                new DbParameter("Symbol", ParameterDirection.Input, symbol)
+                new DbParameter("Symbol", ParameterDirection.Input, symbol),
+                new DbParameter("Option", ParameterDirection.Input, option)
             };
 
             var rows = await _db.ExecuteListAsync<StandingVM>("usp_GetStandingByDate", parameters);

--- a/OTS.Solution/OTS.Infrastructutre/MobileRepository/Implementations/StandingRepository.cs
+++ b/OTS.Solution/OTS.Infrastructutre/MobileRepository/Implementations/StandingRepository.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Threading;
+using System.Threading.Tasks;
+using MobileAccounting.Repositories.Interfaces;
+using OTS.DOMAIN.MobileAccountingVM;
+using OTS.Infrastructutre.Generic.WebBroker.DataAccessCore;
+
+namespace MobileAccounting.Repositories.Implementations
+{
+    public class StandingRepository : IStandingRepository
+    {
+        private readonly DbManager _db;
+
+        public StandingRepository(DbManager db)
+        {
+            _db = db;
+        }
+
+        public async Task<StandingResultVM> GetStandingAsync(DateOnly onDate, long? login, string? symbol, CancellationToken ct)
+        {
+            var parameters = new List<DbParameter>
+            {
+                new DbParameter("OnDate", ParameterDirection.Input, onDate.ToDateTime(TimeOnly.MinValue)),
+                new DbParameter("Login", ParameterDirection.Input, login),
+                new DbParameter("Symbol", ParameterDirection.Input, symbol)
+            };
+
+            var rows = await _db.ExecuteListAsync<StandingVM>("usp_GetStandingByDate", parameters);
+            return new StandingResultVM
+            {
+                Rows = rows,
+                RowCount = rows.Count
+            };
+        }
+    }
+}

--- a/OTS.Solution/OTS.Infrastructutre/MobileRepository/Implementations/StandingRepository.cs
+++ b/OTS.Solution/OTS.Infrastructutre/MobileRepository/Implementations/StandingRepository.cs
@@ -18,11 +18,12 @@ namespace MobileAccounting.Repositories.Implementations
             _db = db;
         }
 
-        public async Task<StandingResultVM> GetStandingAsync(DateOnly onDate, string? symbol, CancellationToken ct)
+        public async Task<StandingResultVM> GetStandingAsync(DateOnly onDate, long? login, string? symbol, CancellationToken ct)
         {
             var parameters = new List<DbParameter>
             {
                 new DbParameter("OnDate", ParameterDirection.Input, onDate.ToDateTime(TimeOnly.MinValue)),
+                new DbParameter("Login", ParameterDirection.Input, login),
                 new DbParameter("Symbol", ParameterDirection.Input, symbol)
             };
 

--- a/OTS.Solution/OTS.Infrastructutre/MobileRepository/Interfaces/IDealHistoryRepository.cs
+++ b/OTS.Solution/OTS.Infrastructutre/MobileRepository/Interfaces/IDealHistoryRepository.cs
@@ -7,6 +7,6 @@ namespace MobileAccounting.Repositories.Interfaces
 {
     public interface IDealHistoryRepository
     {
-        Task<DealHistoryResultVM> GetDealHistoryAsync(DateTime fromDate, DateTime toDate, long? managerId, CancellationToken ct);
+        Task<DealHistoryResultVM> GetDealHistoryAsync(DateTime fromDate, DateTime toDate, long? managerId, long? login, CancellationToken ct);
     }
 }

--- a/OTS.Solution/OTS.Infrastructutre/MobileRepository/Interfaces/IDealHistoryRepository.cs
+++ b/OTS.Solution/OTS.Infrastructutre/MobileRepository/Interfaces/IDealHistoryRepository.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using OTS.DOMAIN.MobileAccountingVM;
+
+namespace MobileAccounting.Repositories.Interfaces
+{
+    public interface IDealHistoryRepository
+    {
+        Task<DealHistoryResultVM> GetDealHistoryAsync(DateTime fromDate, DateTime toDate, long? managerId, CancellationToken ct);
+    }
+}

--- a/OTS.Solution/OTS.Infrastructutre/MobileRepository/Interfaces/ILiveSummaryRepository.cs
+++ b/OTS.Solution/OTS.Infrastructutre/MobileRepository/Interfaces/ILiveSummaryRepository.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using OTS.DOMAIN.MobileAccountingVM;
+
+namespace MobileAccounting.Repositories.Interfaces
+{
+    public interface ILiveSummaryRepository
+    {
+        Task<LiveSummaryResultVM> GetLiveSummaryAsync(DateTime fromDate, DateTime toDate, long? managerId, string? exchange, CancellationToken ct);
+    }
+}

--- a/OTS.Solution/OTS.Infrastructutre/MobileRepository/Interfaces/ILiveSummaryRepository.cs
+++ b/OTS.Solution/OTS.Infrastructutre/MobileRepository/Interfaces/ILiveSummaryRepository.cs
@@ -7,6 +7,6 @@ namespace MobileAccounting.Repositories.Interfaces
 {
     public interface ILiveSummaryRepository
     {
-        Task<LiveSummaryResultVM> GetLiveSummaryAsync(DateTime fromDate, DateTime toDate, long? managerId, string? exchange, CancellationToken ct);
+        Task<LiveSummaryResultVM> GetLiveSummaryAsync(DateTime fromDate, DateTime toDate, long? managerId, string? exchange, string? option, CancellationToken ct);
     }
 }

--- a/OTS.Solution/OTS.Infrastructutre/MobileRepository/Interfaces/IStandingRepository.cs
+++ b/OTS.Solution/OTS.Infrastructutre/MobileRepository/Interfaces/IStandingRepository.cs
@@ -7,6 +7,6 @@ namespace MobileAccounting.Repositories.Interfaces
 {
     public interface IStandingRepository
     {
-        Task<StandingResultVM> GetStandingAsync(DateOnly onDate, string? symbol, CancellationToken ct);
+        Task<StandingResultVM> GetStandingAsync(DateOnly onDate, long? login, string? symbol, CancellationToken ct);
     }
 }

--- a/OTS.Solution/OTS.Infrastructutre/MobileRepository/Interfaces/IStandingRepository.cs
+++ b/OTS.Solution/OTS.Infrastructutre/MobileRepository/Interfaces/IStandingRepository.cs
@@ -7,6 +7,6 @@ namespace MobileAccounting.Repositories.Interfaces
 {
     public interface IStandingRepository
     {
-        Task<StandingResultVM> GetStandingAsync(DateOnly onDate, long? login, string? symbol, CancellationToken ct);
+        Task<StandingResultVM> GetStandingAsync(DateOnly onDate, string? symbol, CancellationToken ct);
     }
 }

--- a/OTS.Solution/OTS.Infrastructutre/MobileRepository/Interfaces/IStandingRepository.cs
+++ b/OTS.Solution/OTS.Infrastructutre/MobileRepository/Interfaces/IStandingRepository.cs
@@ -7,6 +7,6 @@ namespace MobileAccounting.Repositories.Interfaces
 {
     public interface IStandingRepository
     {
-        Task<StandingResultVM> GetStandingAsync(DateOnly onDate, long? login, string? symbol, CancellationToken ct);
+        Task<StandingResultVM> GetStandingAsync(DateOnly onDate, long? login, string? symbol, string? option, CancellationToken ct);
     }
 }

--- a/OTS.Solution/OTS.Infrastructutre/MobileRepository/Interfaces/IStandingRepository.cs
+++ b/OTS.Solution/OTS.Infrastructutre/MobileRepository/Interfaces/IStandingRepository.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using OTS.DOMAIN.MobileAccountingVM;
+
+namespace MobileAccounting.Repositories.Interfaces
+{
+    public interface IStandingRepository
+    {
+        Task<StandingResultVM> GetStandingAsync(DateOnly onDate, long? login, string? symbol, CancellationToken ct);
+    }
+}

--- a/OTS.Solution/OTS.MobileAccountingAPI/Controllers/DealsController.cs
+++ b/OTS.Solution/OTS.MobileAccountingAPI/Controllers/DealsController.cs
@@ -129,6 +129,7 @@ namespace OTS.MobileAccountingAPI.Controllers
             [FromQuery(Name = "to")] string to,
             [FromQuery] long? managerId,
             [FromQuery] string? exchange,
+            [FromQuery] string? option,
             CancellationToken ct = default)
         {
             if (!DateTime.TryParse(from, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var fromDate))
@@ -141,7 +142,7 @@ namespace OTS.MobileAccountingAPI.Controllers
                 return BadRequest("Invalid to date format.");
             }
 
-            var result = await _liveSummaryService.GetLiveSummaryAsync(fromDate, toDate, managerId, exchange, ct);
+            var result = await _liveSummaryService.GetLiveSummaryAsync(fromDate, toDate, managerId, exchange, option, ct);
             return Ok(new { rows = result.Rows, rowCount = result.RowCount });
         }
 

--- a/OTS.Solution/OTS.MobileAccountingAPI/Controllers/DealsController.cs
+++ b/OTS.Solution/OTS.MobileAccountingAPI/Controllers/DealsController.cs
@@ -109,7 +109,6 @@ namespace OTS.MobileAccountingAPI.Controllers
         [HttpGet("standing")]
         public async Task<IActionResult> GetStanding(
             [FromQuery(Name = "date")] string date,
-            [FromQuery] long? login,
             [FromQuery] string? symbol,
             CancellationToken ct = default)
         {
@@ -118,7 +117,7 @@ namespace OTS.MobileAccountingAPI.Controllers
                 return BadRequest("Invalid date format.");
             }
 
-            var result = await _standingService.GetStandingAsync(onDate, login, symbol, ct);
+            var result = await _standingService.GetStandingAsync(onDate, symbol, ct);
             return Ok(new { rows = result.Rows, rowCount = result.RowCount });
         }
 

--- a/OTS.Solution/OTS.MobileAccountingAPI/Controllers/DealsController.cs
+++ b/OTS.Solution/OTS.MobileAccountingAPI/Controllers/DealsController.cs
@@ -12,12 +12,18 @@ namespace OTS.MobileAccountingAPI.Controllers
         private readonly ILiveDealService _liveDealService;
         private readonly IOrderSnapshotService _orderSnapshotService;
         private readonly IJobbingDealService _jobbingDealService;
+        private readonly IStandingService _standingService;
 
-        public DealsController(ILiveDealService liveDealService, IOrderSnapshotService orderSnapshotService, IJobbingDealService jobbingDealService)
+        public DealsController(
+            ILiveDealService liveDealService,
+            IOrderSnapshotService orderSnapshotService,
+            IJobbingDealService jobbingDealService,
+            IStandingService standingService)
         {
             _liveDealService = liveDealService;
             _orderSnapshotService = orderSnapshotService;
             _jobbingDealService = jobbingDealService;
+            _standingService = standingService;
         }
 
         [HttpGet("live")]
@@ -92,6 +98,22 @@ namespace OTS.MobileAccountingAPI.Controllers
 
             var result = await _jobbingDealService.GetJobbingDealsAsync(parsedFrom, parsedTo, intervalMinutes, login, symbol, ct);
             return Ok(new { rows = result.Rows, maxTime = result.MaxTime, rowCount = result.RowsCount });
+        }
+
+        [HttpGet("standing")]
+        public async Task<IActionResult> GetStanding(
+            [FromQuery(Name = "date")] string date,
+            [FromQuery] long? login,
+            [FromQuery] string? symbol,
+            CancellationToken ct = default)
+        {
+            if (!DateOnly.TryParse(date, CultureInfo.InvariantCulture, DateTimeStyles.None, out var onDate))
+            {
+                return BadRequest("Invalid date format.");
+            }
+
+            var result = await _standingService.GetStandingAsync(onDate, login, symbol, ct);
+            return Ok(new { rows = result.Rows, rowCount = result.RowCount });
         }
     }
 }

--- a/OTS.Solution/OTS.MobileAccountingAPI/Controllers/DealsController.cs
+++ b/OTS.Solution/OTS.MobileAccountingAPI/Controllers/DealsController.cs
@@ -149,6 +149,7 @@ namespace OTS.MobileAccountingAPI.Controllers
             [FromQuery(Name = "from")] string from,
             [FromQuery(Name = "to")] string to,
             [FromQuery] long? managerId,
+            [FromQuery] long? login,
             CancellationToken ct = default)
         {
             if (!DateTime.TryParse(from, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var fromDate))
@@ -161,7 +162,7 @@ namespace OTS.MobileAccountingAPI.Controllers
                 return BadRequest("Invalid to date format.");
             }
 
-            var result = await _dealHistoryService.GetDealHistoryAsync(fromDate, toDate, managerId, ct);
+            var result = await _dealHistoryService.GetDealHistoryAsync(fromDate, toDate, managerId, login, ct);
             return Ok(new { rows = result.Rows, rowCount = result.RowCount });
         }
     }

--- a/OTS.Solution/OTS.MobileAccountingAPI/Controllers/DealsController.cs
+++ b/OTS.Solution/OTS.MobileAccountingAPI/Controllers/DealsController.cs
@@ -14,19 +14,22 @@ namespace OTS.MobileAccountingAPI.Controllers
         private readonly IJobbingDealService _jobbingDealService;
         private readonly IStandingService _standingService;
         private readonly ILiveSummaryService _liveSummaryService;
+        private readonly IDealHistoryService _dealHistoryService;
 
         public DealsController(
             ILiveDealService liveDealService,
             IOrderSnapshotService orderSnapshotService,
             IJobbingDealService jobbingDealService,
             IStandingService standingService,
-            ILiveSummaryService liveSummaryService)
+            ILiveSummaryService liveSummaryService,
+            IDealHistoryService dealHistoryService)
         {
             _liveDealService = liveDealService;
             _orderSnapshotService = orderSnapshotService;
             _jobbingDealService = jobbingDealService;
             _standingService = standingService;
             _liveSummaryService = liveSummaryService;
+            _dealHistoryService = dealHistoryService;
         }
 
         [HttpGet("live")]
@@ -138,6 +141,27 @@ namespace OTS.MobileAccountingAPI.Controllers
             }
 
             var result = await _liveSummaryService.GetLiveSummaryAsync(fromDate, toDate, managerId, exchange, ct);
+            return Ok(new { rows = result.Rows, rowCount = result.RowCount });
+        }
+
+        [HttpGet("deal-history")]
+        public async Task<IActionResult> GetDealHistory(
+            [FromQuery(Name = "from")] string from,
+            [FromQuery(Name = "to")] string to,
+            [FromQuery] long? managerId,
+            CancellationToken ct = default)
+        {
+            if (!DateTime.TryParse(from, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var fromDate))
+            {
+                return BadRequest("Invalid from date format.");
+            }
+
+            if (!DateTime.TryParse(to, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var toDate))
+            {
+                return BadRequest("Invalid to date format.");
+            }
+
+            var result = await _dealHistoryService.GetDealHistoryAsync(fromDate, toDate, managerId, ct);
             return Ok(new { rows = result.Rows, rowCount = result.RowCount });
         }
     }

--- a/OTS.Solution/OTS.MobileAccountingAPI/Controllers/DealsController.cs
+++ b/OTS.Solution/OTS.MobileAccountingAPI/Controllers/DealsController.cs
@@ -109,6 +109,7 @@ namespace OTS.MobileAccountingAPI.Controllers
         [HttpGet("standing")]
         public async Task<IActionResult> GetStanding(
             [FromQuery(Name = "date")] string date,
+            [FromQuery] long? login,
             [FromQuery] string? symbol,
             CancellationToken ct = default)
         {
@@ -117,7 +118,7 @@ namespace OTS.MobileAccountingAPI.Controllers
                 return BadRequest("Invalid date format.");
             }
 
-            var result = await _standingService.GetStandingAsync(onDate, symbol, ct);
+            var result = await _standingService.GetStandingAsync(onDate, login, symbol, ct);
             return Ok(new { rows = result.Rows, rowCount = result.RowCount });
         }
 

--- a/OTS.Solution/OTS.MobileAccountingAPI/Controllers/DealsController.cs
+++ b/OTS.Solution/OTS.MobileAccountingAPI/Controllers/DealsController.cs
@@ -111,6 +111,7 @@ namespace OTS.MobileAccountingAPI.Controllers
             [FromQuery(Name = "date")] string date,
             [FromQuery] long? login,
             [FromQuery] string? symbol,
+            [FromQuery] string? option,
             CancellationToken ct = default)
         {
             if (!DateOnly.TryParse(date, CultureInfo.InvariantCulture, DateTimeStyles.None, out var onDate))
@@ -118,7 +119,7 @@ namespace OTS.MobileAccountingAPI.Controllers
                 return BadRequest("Invalid date format.");
             }
 
-            var result = await _standingService.GetStandingAsync(onDate, login, symbol, ct);
+            var result = await _standingService.GetStandingAsync(onDate, login, symbol, option, ct);
             return Ok(new { rows = result.Rows, rowCount = result.RowCount });
         }
 

--- a/OTS.Solution/OTS.MobileAccountingAPI/Controllers/DealsController.cs
+++ b/OTS.Solution/OTS.MobileAccountingAPI/Controllers/DealsController.cs
@@ -13,17 +13,20 @@ namespace OTS.MobileAccountingAPI.Controllers
         private readonly IOrderSnapshotService _orderSnapshotService;
         private readonly IJobbingDealService _jobbingDealService;
         private readonly IStandingService _standingService;
+        private readonly ILiveSummaryService _liveSummaryService;
 
         public DealsController(
             ILiveDealService liveDealService,
             IOrderSnapshotService orderSnapshotService,
             IJobbingDealService jobbingDealService,
-            IStandingService standingService)
+            IStandingService standingService,
+            ILiveSummaryService liveSummaryService)
         {
             _liveDealService = liveDealService;
             _orderSnapshotService = orderSnapshotService;
             _jobbingDealService = jobbingDealService;
             _standingService = standingService;
+            _liveSummaryService = liveSummaryService;
         }
 
         [HttpGet("live")]
@@ -113,6 +116,28 @@ namespace OTS.MobileAccountingAPI.Controllers
             }
 
             var result = await _standingService.GetStandingAsync(onDate, login, symbol, ct);
+            return Ok(new { rows = result.Rows, rowCount = result.RowCount });
+        }
+
+        [HttpGet("live-summary")]
+        public async Task<IActionResult> GetLiveSummary(
+            [FromQuery(Name = "from")] string from,
+            [FromQuery(Name = "to")] string to,
+            [FromQuery] long? managerId,
+            [FromQuery] string? exchange,
+            CancellationToken ct = default)
+        {
+            if (!DateTime.TryParse(from, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var fromDate))
+            {
+                return BadRequest("Invalid from date format.");
+            }
+
+            if (!DateTime.TryParse(to, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var toDate))
+            {
+                return BadRequest("Invalid to date format.");
+            }
+
+            var result = await _liveSummaryService.GetLiveSummaryAsync(fromDate, toDate, managerId, exchange, ct);
             return Ok(new { rows = result.Rows, rowCount = result.RowCount });
         }
     }

--- a/OTS.Solution/OTS.Service/DealHistoryService.cs
+++ b/OTS.Solution/OTS.Service/DealHistoryService.cs
@@ -16,9 +16,9 @@ namespace OTS.Service
             _repository = repository;
         }
 
-        public Task<DealHistoryResultVM> GetDealHistoryAsync(DateTime fromDate, DateTime toDate, long? managerId, CancellationToken ct)
+        public Task<DealHistoryResultVM> GetDealHistoryAsync(DateTime fromDate, DateTime toDate, long? managerId, long? login, CancellationToken ct)
         {
-            return _repository.GetDealHistoryAsync(fromDate, toDate, managerId, ct);
+            return _repository.GetDealHistoryAsync(fromDate, toDate, managerId, login, ct);
         }
     }
 }

--- a/OTS.Solution/OTS.Service/DealHistoryService.cs
+++ b/OTS.Solution/OTS.Service/DealHistoryService.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MobileAccounting.Repositories.Interfaces;
+using OTS.DOMAIN.MobileAccountingVM;
+using OTS.Service.Interfaces;
+
+namespace OTS.Service
+{
+    public class DealHistoryService : IDealHistoryService
+    {
+        private readonly IDealHistoryRepository _repository;
+
+        public DealHistoryService(IDealHistoryRepository repository)
+        {
+            _repository = repository;
+        }
+
+        public Task<DealHistoryResultVM> GetDealHistoryAsync(DateTime fromDate, DateTime toDate, long? managerId, CancellationToken ct)
+        {
+            return _repository.GetDealHistoryAsync(fromDate, toDate, managerId, ct);
+        }
+    }
+}

--- a/OTS.Solution/OTS.Service/DependencyInjection.cs
+++ b/OTS.Solution/OTS.Service/DependencyInjection.cs
@@ -43,6 +43,7 @@ namespace OTS.Service
             services.AddScoped<IOrderSnapshotRepository, OrderSnapshotRepository>();
             services.AddScoped<IJobbingDealRepository, JobbingDealRepository>();
             services.AddScoped<IStandingRepository, StandingRepository>();
+            services.AddScoped<ILiveSummaryRepository, LiveSummaryRepository>();
             services.AddScoped<IMasterRepository, MasterRepository>();
 
             services.AddScoped<IUnitOfWork, UnitOfWork>();
@@ -55,6 +56,7 @@ namespace OTS.Service
             services.AddScoped<IOrderSnapshotService, OrderSnapshotService>();
             services.AddScoped<IJobbingDealService, JobbingDealService>();
             services.AddScoped<IStandingService, StandingService>();
+            services.AddScoped<ILiveSummaryService, LiveSummaryService>();
             services.AddScoped<IMasterService, MasterService>();
 
             return services;

--- a/OTS.Solution/OTS.Service/DependencyInjection.cs
+++ b/OTS.Solution/OTS.Service/DependencyInjection.cs
@@ -44,6 +44,7 @@ namespace OTS.Service
             services.AddScoped<IJobbingDealRepository, JobbingDealRepository>();
             services.AddScoped<IStandingRepository, StandingRepository>();
             services.AddScoped<ILiveSummaryRepository, LiveSummaryRepository>();
+            services.AddScoped<IDealHistoryRepository, DealHistoryRepository>();
             services.AddScoped<IMasterRepository, MasterRepository>();
 
             services.AddScoped<IUnitOfWork, UnitOfWork>();
@@ -57,6 +58,7 @@ namespace OTS.Service
             services.AddScoped<IJobbingDealService, JobbingDealService>();
             services.AddScoped<IStandingService, StandingService>();
             services.AddScoped<ILiveSummaryService, LiveSummaryService>();
+            services.AddScoped<IDealHistoryService, DealHistoryService>();
             services.AddScoped<IMasterService, MasterService>();
 
             return services;

--- a/OTS.Solution/OTS.Service/DependencyInjection.cs
+++ b/OTS.Solution/OTS.Service/DependencyInjection.cs
@@ -42,6 +42,7 @@ namespace OTS.Service
             services.AddScoped<ILiveDealRepository, LiveDealRepository>();
             services.AddScoped<IOrderSnapshotRepository, OrderSnapshotRepository>();
             services.AddScoped<IJobbingDealRepository, JobbingDealRepository>();
+            services.AddScoped<IStandingRepository, StandingRepository>();
             services.AddScoped<IMasterRepository, MasterRepository>();
 
             services.AddScoped<IUnitOfWork, UnitOfWork>();
@@ -53,6 +54,7 @@ namespace OTS.Service
             services.AddScoped<IAuthService, AuthService>();
             services.AddScoped<IOrderSnapshotService, OrderSnapshotService>();
             services.AddScoped<IJobbingDealService, JobbingDealService>();
+            services.AddScoped<IStandingService, StandingService>();
             services.AddScoped<IMasterService, MasterService>();
 
             return services;

--- a/OTS.Solution/OTS.Service/Interfaces/IDealHistoryService.cs
+++ b/OTS.Solution/OTS.Service/Interfaces/IDealHistoryService.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using OTS.DOMAIN.MobileAccountingVM;
+
+namespace OTS.Service.Interfaces
+{
+    public interface IDealHistoryService
+    {
+        Task<DealHistoryResultVM> GetDealHistoryAsync(DateTime fromDate, DateTime toDate, long? managerId, CancellationToken ct);
+    }
+}

--- a/OTS.Solution/OTS.Service/Interfaces/IDealHistoryService.cs
+++ b/OTS.Solution/OTS.Service/Interfaces/IDealHistoryService.cs
@@ -7,6 +7,6 @@ namespace OTS.Service.Interfaces
 {
     public interface IDealHistoryService
     {
-        Task<DealHistoryResultVM> GetDealHistoryAsync(DateTime fromDate, DateTime toDate, long? managerId, CancellationToken ct);
+        Task<DealHistoryResultVM> GetDealHistoryAsync(DateTime fromDate, DateTime toDate, long? managerId, long? login, CancellationToken ct);
     }
 }

--- a/OTS.Solution/OTS.Service/Interfaces/ILiveSummaryService.cs
+++ b/OTS.Solution/OTS.Service/Interfaces/ILiveSummaryService.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using OTS.DOMAIN.MobileAccountingVM;
+
+namespace OTS.Service.Interfaces
+{
+    public interface ILiveSummaryService
+    {
+        Task<LiveSummaryResultVM> GetLiveSummaryAsync(DateTime fromDate, DateTime toDate, long? managerId, string? exchange, CancellationToken ct);
+    }
+}

--- a/OTS.Solution/OTS.Service/Interfaces/ILiveSummaryService.cs
+++ b/OTS.Solution/OTS.Service/Interfaces/ILiveSummaryService.cs
@@ -7,6 +7,6 @@ namespace OTS.Service.Interfaces
 {
     public interface ILiveSummaryService
     {
-        Task<LiveSummaryResultVM> GetLiveSummaryAsync(DateTime fromDate, DateTime toDate, long? managerId, string? exchange, CancellationToken ct);
+        Task<LiveSummaryResultVM> GetLiveSummaryAsync(DateTime fromDate, DateTime toDate, long? managerId, string? exchange, string? option, CancellationToken ct);
     }
 }

--- a/OTS.Solution/OTS.Service/Interfaces/IStandingService.cs
+++ b/OTS.Solution/OTS.Service/Interfaces/IStandingService.cs
@@ -7,6 +7,6 @@ namespace OTS.Service.Interfaces
 {
     public interface IStandingService
     {
-        Task<StandingResultVM> GetStandingAsync(DateOnly onDate, long? login, string? symbol, CancellationToken ct);
+        Task<StandingResultVM> GetStandingAsync(DateOnly onDate, string? symbol, CancellationToken ct);
     }
 }

--- a/OTS.Solution/OTS.Service/Interfaces/IStandingService.cs
+++ b/OTS.Solution/OTS.Service/Interfaces/IStandingService.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using OTS.DOMAIN.MobileAccountingVM;
+
+namespace OTS.Service.Interfaces
+{
+    public interface IStandingService
+    {
+        Task<StandingResultVM> GetStandingAsync(DateOnly onDate, long? login, string? symbol, CancellationToken ct);
+    }
+}

--- a/OTS.Solution/OTS.Service/Interfaces/IStandingService.cs
+++ b/OTS.Solution/OTS.Service/Interfaces/IStandingService.cs
@@ -7,6 +7,6 @@ namespace OTS.Service.Interfaces
 {
     public interface IStandingService
     {
-        Task<StandingResultVM> GetStandingAsync(DateOnly onDate, long? login, string? symbol, CancellationToken ct);
+        Task<StandingResultVM> GetStandingAsync(DateOnly onDate, long? login, string? symbol, string? option, CancellationToken ct);
     }
 }

--- a/OTS.Solution/OTS.Service/Interfaces/IStandingService.cs
+++ b/OTS.Solution/OTS.Service/Interfaces/IStandingService.cs
@@ -7,6 +7,6 @@ namespace OTS.Service.Interfaces
 {
     public interface IStandingService
     {
-        Task<StandingResultVM> GetStandingAsync(DateOnly onDate, string? symbol, CancellationToken ct);
+        Task<StandingResultVM> GetStandingAsync(DateOnly onDate, long? login, string? symbol, CancellationToken ct);
     }
 }

--- a/OTS.Solution/OTS.Service/LiveSummaryService.cs
+++ b/OTS.Solution/OTS.Service/LiveSummaryService.cs
@@ -16,9 +16,9 @@ namespace OTS.Service
             _repository = repository;
         }
 
-        public Task<LiveSummaryResultVM> GetLiveSummaryAsync(DateTime fromDate, DateTime toDate, long? managerId, string? exchange, CancellationToken ct)
+        public Task<LiveSummaryResultVM> GetLiveSummaryAsync(DateTime fromDate, DateTime toDate, long? managerId, string? exchange, string? option, CancellationToken ct)
         {
-            return _repository.GetLiveSummaryAsync(fromDate, toDate, managerId, exchange, ct);
+            return _repository.GetLiveSummaryAsync(fromDate, toDate, managerId, exchange, option, ct);
         }
     }
 }

--- a/OTS.Solution/OTS.Service/LiveSummaryService.cs
+++ b/OTS.Solution/OTS.Service/LiveSummaryService.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MobileAccounting.Repositories.Interfaces;
+using OTS.DOMAIN.MobileAccountingVM;
+using OTS.Service.Interfaces;
+
+namespace OTS.Service
+{
+    public class LiveSummaryService : ILiveSummaryService
+    {
+        private readonly ILiveSummaryRepository _repository;
+
+        public LiveSummaryService(ILiveSummaryRepository repository)
+        {
+            _repository = repository;
+        }
+
+        public Task<LiveSummaryResultVM> GetLiveSummaryAsync(DateTime fromDate, DateTime toDate, long? managerId, string? exchange, CancellationToken ct)
+        {
+            return _repository.GetLiveSummaryAsync(fromDate, toDate, managerId, exchange, ct);
+        }
+    }
+}

--- a/OTS.Solution/OTS.Service/StandingService.cs
+++ b/OTS.Solution/OTS.Service/StandingService.cs
@@ -16,9 +16,9 @@ namespace OTS.Service
             _repository = repository;
         }
 
-        public Task<StandingResultVM> GetStandingAsync(DateOnly onDate, string? symbol, CancellationToken ct)
+        public Task<StandingResultVM> GetStandingAsync(DateOnly onDate, long? login, string? symbol, CancellationToken ct)
         {
-            return _repository.GetStandingAsync(onDate, symbol, ct);
+            return _repository.GetStandingAsync(onDate, login, symbol, ct);
         }
     }
 }

--- a/OTS.Solution/OTS.Service/StandingService.cs
+++ b/OTS.Solution/OTS.Service/StandingService.cs
@@ -16,9 +16,9 @@ namespace OTS.Service
             _repository = repository;
         }
 
-        public Task<StandingResultVM> GetStandingAsync(DateOnly onDate, long? login, string? symbol, CancellationToken ct)
+        public Task<StandingResultVM> GetStandingAsync(DateOnly onDate, long? login, string? symbol, string? option, CancellationToken ct)
         {
-            return _repository.GetStandingAsync(onDate, login, symbol, ct);
+            return _repository.GetStandingAsync(onDate, login, symbol, option, ct);
         }
     }
 }

--- a/OTS.Solution/OTS.Service/StandingService.cs
+++ b/OTS.Solution/OTS.Service/StandingService.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MobileAccounting.Repositories.Interfaces;
+using OTS.DOMAIN.MobileAccountingVM;
+using OTS.Service.Interfaces;
+
+namespace OTS.Service
+{
+    public class StandingService : IStandingService
+    {
+        private readonly IStandingRepository _repository;
+
+        public StandingService(IStandingRepository repository)
+        {
+            _repository = repository;
+        }
+
+        public Task<StandingResultVM> GetStandingAsync(DateOnly onDate, long? login, string? symbol, CancellationToken ct)
+        {
+            return _repository.GetStandingAsync(onDate, login, symbol, ct);
+        }
+    }
+}

--- a/OTS.Solution/OTS.Service/StandingService.cs
+++ b/OTS.Solution/OTS.Service/StandingService.cs
@@ -16,9 +16,9 @@ namespace OTS.Service
             _repository = repository;
         }
 
-        public Task<StandingResultVM> GetStandingAsync(DateOnly onDate, long? login, string? symbol, CancellationToken ct)
+        public Task<StandingResultVM> GetStandingAsync(DateOnly onDate, string? symbol, CancellationToken ct)
         {
-            return _repository.GetStandingAsync(onDate, login, symbol, ct);
+            return _repository.GetStandingAsync(onDate, symbol, ct);
         }
     }
 }


### PR DESCRIPTION
## Summary
- expose `GET /api/deals/standing` to retrieve standing quantities by date with optional login and symbol filters
- implement standing service and repository that execute `usp_GetStandingByDate`
- register standing dependencies and add view models for the result

## Testing
- `dotnet build OTS.Solution/OTS.Solution.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ab0ed25fb083309ac869bb0c10de36