### PR TITLE
Add cross trade pairs endpoint

### DIFF
--- a/OTS.Solution/OTS.DOMAIN/MobileAccountingVM/CrossTradePairDetailVM.cs
+++ b/OTS.Solution/OTS.DOMAIN/MobileAccountingVM/CrossTradePairDetailVM.cs
@@ -1,0 +1,24 @@
+using System;
+
+namespace OTS.DOMAIN.MobileAccountingVM
+{
+    public class CrossTradePairDetailVM
+    {
+        public string? Symbol { get; set; }
+        public string? LastIP { get; set; }
+        public long? Login1 { get; set; }
+        public long? Login2 { get; set; }
+        public string? RowSide { get; set; }
+        public long? Login { get; set; }
+        public DateTime? Time { get; set; }
+        public long? Deal { get; set; }
+        public string? ConType { get; set; }
+        public decimal? Qty { get; set; }
+        public decimal? Price { get; set; }
+        public decimal? Volume { get; set; }
+        public decimal? Volumeext { get; set; }
+        public decimal? Profit { get; set; }
+        public decimal? Commission { get; set; }
+        public string? Comment { get; set; }
+    }
+}

--- a/OTS.Solution/OTS.DOMAIN/MobileAccountingVM/CrossTradePairResultVM.cs
+++ b/OTS.Solution/OTS.DOMAIN/MobileAccountingVM/CrossTradePairResultVM.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+namespace OTS.DOMAIN.MobileAccountingVM
+{
+    public class CrossTradePairResultVM
+    {
+        public List<CrossTradePairVM> Pairs { get; set; } = new();
+        public List<CrossTradePairDetailVM> Details { get; set; } = new();
+    }
+}

--- a/OTS.Solution/OTS.DOMAIN/MobileAccountingVM/CrossTradePairVM.cs
+++ b/OTS.Solution/OTS.DOMAIN/MobileAccountingVM/CrossTradePairVM.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace OTS.DOMAIN.MobileAccountingVM
+{
+    public class CrossTradePairVM
+    {
+        public string? Symbol { get; set; }
+        public string? LastIP { get; set; }
+        public long? Login1 { get; set; }
+        public long? Login2 { get; set; }
+        public DateTime? FirstTradeTime { get; set; }
+        public DateTime? LastTradeTime { get; set; }
+        public int? Deals { get; set; }
+        public int? BDeals { get; set; }
+        public int? SDeals { get; set; }
+    }
+}

--- a/OTS.Solution/OTS.Infrastructutre/MobileRepository/Implementations/LiveDealRepository.cs
+++ b/OTS.Solution/OTS.Infrastructutre/MobileRepository/Implementations/LiveDealRepository.cs
@@ -44,5 +44,24 @@ namespace MobileAccounting.Repositories.Implementations
                 TotalRows = meta?.TotalRows
             };
         }
+
+        public async Task<CrossTradePairResultVM> GetCrossTradePairsAsync(DateTime? fromTime, DateTime? toTime, CancellationToken ct)
+        {
+            var parameters = new List<DbParameter>
+            {
+                new DbParameter("FromTime", ParameterDirection.Input, fromTime),
+                new DbParameter("ToTime", ParameterDirection.Input, toTime)
+            };
+
+            var (pairs, details) = await _db.ExecuteMultipleListAsync<CrossTradePairVM, CrossTradePairDetailVM>(
+                "usp_GetCrossTradePairs_WithTime",
+                parameters);
+
+            return new CrossTradePairResultVM
+            {
+                Pairs = pairs,
+                Details = details
+            };
+        }
     }
 }

--- a/OTS.Solution/OTS.Infrastructutre/MobileRepository/Interfaces/ILiveDealRepository.cs
+++ b/OTS.Solution/OTS.Infrastructutre/MobileRepository/Interfaces/ILiveDealRepository.cs
@@ -8,5 +8,6 @@ namespace MobileAccounting.Repositories.Interfaces
     public interface ILiveDealRepository
     {
         Task<LiveDealResultVM> GetLiveDealsAsync(DateOnly onDate, DateTime? sinceTime, string? symbol, string? action, int pageSize, bool asc, CancellationToken ct);
+        Task<CrossTradePairResultVM> GetCrossTradePairsAsync(DateTime? fromTime, DateTime? toTime, CancellationToken ct);
     }
 }

--- a/OTS.Solution/OTS.MobileAccountingAPI/Controllers/DealsController.cs
+++ b/OTS.Solution/OTS.MobileAccountingAPI/Controllers/DealsController.cs
@@ -62,6 +62,38 @@ namespace OTS.MobileAccountingAPI.Controllers
             return Ok(new { rows = result.Rows, maxTime = result.MaxTime, rowCount = result.TotalRows });
         }
 
+        [HttpGet("cross-trade-pairs")]
+        public async Task<IActionResult> GetCrossTradePairs(
+            [FromQuery(Name = "from")] string? from,
+            [FromQuery(Name = "to")] string? to,
+            CancellationToken ct = default)
+        {
+            DateTime? fromTime = null;
+            if (!string.IsNullOrWhiteSpace(from))
+            {
+                if (!DateTime.TryParse(from, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var fromValue))
+                {
+                    return BadRequest("Invalid from time format.");
+                }
+
+                fromTime = fromValue;
+            }
+
+            DateTime? toTime = null;
+            if (!string.IsNullOrWhiteSpace(to))
+            {
+                if (!DateTime.TryParse(to, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var toValue))
+                {
+                    return BadRequest("Invalid to time format.");
+                }
+
+                toTime = toValue;
+            }
+
+            var result = await _liveDealService.GetCrossTradePairsAsync(fromTime, toTime, ct);
+            return Ok(new { rows = result.Pairs, details = result.Details });
+        }
+
         [HttpGet("orders-snapshot")]
         public async Task<IActionResult> GetOrdersSnapshot(
             [FromQuery] string? symbol,

--- a/OTS.Solution/OTS.Service/Interfaces/ILiveDealService.cs
+++ b/OTS.Solution/OTS.Service/Interfaces/ILiveDealService.cs
@@ -8,5 +8,6 @@ namespace OTS.Service.Interfaces
     public interface ILiveDealService
     {
         Task<LiveDealResultVM> GetLiveDealsAsync(DateOnly onDate, DateTime? sinceTime, string? symbol, string? action, int pageSize, bool asc, CancellationToken ct);
+        Task<CrossTradePairResultVM> GetCrossTradePairsAsync(DateTime? fromTime, DateTime? toTime, CancellationToken ct);
     }
 }

--- a/OTS.Solution/OTS.Service/LiveDealService.cs
+++ b/OTS.Solution/OTS.Service/LiveDealService.cs
@@ -20,5 +20,10 @@ namespace OTS.Service
         {
             return _repository.GetLiveDealsAsync(onDate, sinceTime, symbol, action, pageSize, asc, ct);
         }
+
+        public Task<CrossTradePairResultVM> GetCrossTradePairsAsync(DateTime? fromTime, DateTime? toTime, CancellationToken ct)
+        {
+            return _repository.GetCrossTradePairsAsync(fromTime, toTime, ct);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add view models for cross trade pair summary and details returned by usp_GetCrossTradePairs_WithTime
- extend database manager, repository, and service layers to surface the stored procedure results
- expose a new DealsController endpoint that validates optional time filters and returns the procedure output

## Testing
- dotnet build OTS.Solution/OTS.Solution.sln *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d0dc65905c833090afad779f75a517