### PR TITLE
Add DiffIP cross trade pairs support

### DIFF
--- a/OTS.Solution/OTS.DOMAIN/MobileAccountingVM/CrossTradePairDiffIpVM.cs
+++ b/OTS.Solution/OTS.DOMAIN/MobileAccountingVM/CrossTradePairDiffIpVM.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace OTS.DOMAIN.MobileAccountingVM
+{
+    public class CrossTradePairDiffIpVM
+    {
+        public string? Symbol { get; set; }
+        public long? Login1 { get; set; }
+        public string? IP1 { get; set; }
+        public long? Login2 { get; set; }
+        public string? IP2 { get; set; }
+        public long? BuyDeal { get; set; }
+        public long? SellDeal { get; set; }
+        public decimal? Qty { get; set; }
+        public DateTime? BuyTime { get; set; }
+        public DateTime? SellTime { get; set; }
+        public int? DiffSec { get; set; }
+        public decimal? BuyProfit { get; set; }
+        public decimal? SellProfit { get; set; }
+        public decimal? TotalProfit { get; set; }
+    }
+}

--- a/OTS.Solution/OTS.Infrastructutre/MobileRepository/Implementations/LiveDealRepository.cs
+++ b/OTS.Solution/OTS.Infrastructutre/MobileRepository/Implementations/LiveDealRepository.cs
@@ -1,7 +1,9 @@
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
 using MobileAccounting.Repositories.Interfaces;
 using OTS.DOMAIN.MobileAccountingVM;
 using OTS.Infrastructutre.Generic.WebBroker.DataAccessCore;
-using System.Data;
 
 namespace MobileAccounting.Repositories.Implementations
 {
@@ -57,6 +59,19 @@ namespace MobileAccounting.Repositories.Implementations
                 Pairs = pairs,
                 Details = details
             };
+        }
+
+        public Task<List<CrossTradePairDiffIpVM>> GetCrossTradePairsDiffIpAsync(DateTime? fromTime, DateTime? toTime, CancellationToken ct)
+        {
+            var parameters = new List<DbParameter>
+            {
+                new DbParameter("FROMDATE", ParameterDirection.Input, fromTime),
+                new DbParameter("TODATE", ParameterDirection.Input, toTime)
+            };
+
+            return _db.ExecuteListAsync<CrossTradePairDiffIpVM>(
+                "usp_GetCrossTradePairs_DiffIP",
+                parameters);
         }
     }
 }

--- a/OTS.Solution/OTS.Infrastructutre/MobileRepository/Interfaces/ILiveDealRepository.cs
+++ b/OTS.Solution/OTS.Infrastructutre/MobileRepository/Interfaces/ILiveDealRepository.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using OTS.DOMAIN.MobileAccountingVM;
@@ -9,5 +10,6 @@ namespace MobileAccounting.Repositories.Interfaces
     {
         Task<LiveDealResultVM> GetLiveDealsAsync(DateOnly onDate, DateTime? sinceTime, string? symbol, string? action, int pageSize, bool asc, CancellationToken ct);
         Task<CrossTradePairResultVM> GetCrossTradePairsAsync(DateTime? fromTime, DateTime? toTime, CancellationToken ct);
+        Task<List<CrossTradePairDiffIpVM>> GetCrossTradePairsDiffIpAsync(DateTime? fromTime, DateTime? toTime, CancellationToken ct);
     }
 }

--- a/OTS.Solution/OTS.MobileAccountingAPI/Controllers/DealsController.cs
+++ b/OTS.Solution/OTS.MobileAccountingAPI/Controllers/DealsController.cs
@@ -66,6 +66,7 @@ namespace OTS.MobileAccountingAPI.Controllers
         public async Task<IActionResult> GetCrossTradePairs(
             [FromQuery(Name = "from")] string? from,
             [FromQuery(Name = "to")] string? to,
+            [FromQuery(Name = "type")] string? type,
             CancellationToken ct = default)
         {
             try
@@ -92,6 +93,12 @@ namespace OTS.MobileAccountingAPI.Controllers
                     }
 
                     toTime = toValue;
+                }
+
+                if (string.Equals(type, "DiffIP", StringComparison.OrdinalIgnoreCase))
+                {
+                    var diffIpResult = await _liveDealService.GetCrossTradePairsDiffIpAsync(fromTime, toTime, ct);
+                    return Ok(new { rows = diffIpResult });
                 }
 
                 var result = await _liveDealService.GetCrossTradePairsAsync(fromTime, toTime, ct);

--- a/OTS.Solution/OTS.MobileAccountingAPI/Controllers/DealsController.cs
+++ b/OTS.Solution/OTS.MobileAccountingAPI/Controllers/DealsController.cs
@@ -69,46 +69,42 @@ namespace OTS.MobileAccountingAPI.Controllers
             [FromQuery(Name = "type")] string? type,
             CancellationToken ct = default)
         {
-            try
+            if (!TryParseUtcDateTime(from, out var fromTime))
             {
-
-
-                DateTime? fromTime = null;
-                if (!string.IsNullOrWhiteSpace(from))
-                {
-                    if (!DateTime.TryParse(from, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var fromValue))
-                    {
-                        return BadRequest("Invalid from time format.");
-                    }
-
-                    fromTime = fromValue;
-                }
-
-                DateTime? toTime = null;
-                if (!string.IsNullOrWhiteSpace(to))
-                {
-                    if (!DateTime.TryParse(to, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var toValue))
-                    {
-                        return BadRequest("Invalid to time format.");
-                    }
-
-                    toTime = toValue;
-                }
-
-                if (string.Equals(type, "DiffIP", StringComparison.OrdinalIgnoreCase))
-                {
-                    var diffIpResult = await _liveDealService.GetCrossTradePairsDiffIpAsync(fromTime, toTime, ct);
-                    return Ok(new { rows = diffIpResult });
-                }
-
-                var result = await _liveDealService.GetCrossTradePairsAsync(fromTime, toTime, ct);
-                return Ok(new { rows = result.Pairs, details = result.Details });
+                return BadRequest("Invalid from time format.");
             }
-            catch (Exception ex )
+
+            if (!TryParseUtcDateTime(to, out var toTime))
             {
-
-                throw;
+                return BadRequest("Invalid to time format.");
             }
+
+            if (!string.IsNullOrWhiteSpace(type) && string.Equals(type.Trim(), "DiffIP", StringComparison.OrdinalIgnoreCase))
+            {
+                var diffIpResult = await _liveDealService.GetCrossTradePairsDiffIpAsync(fromTime, toTime, ct).ConfigureAwait(false);
+                return Ok(new { rows = diffIpResult });
+            }
+
+            var result = await _liveDealService.GetCrossTradePairsAsync(fromTime, toTime, ct).ConfigureAwait(false);
+            return Ok(new { rows = result.Pairs, details = result.Details });
+        }
+
+        private static bool TryParseUtcDateTime(string? value, out DateTime? parsed)
+        {
+            parsed = null;
+
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return true;
+            }
+
+            if (DateTime.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var parsedValue))
+            {
+                parsed = parsedValue;
+                return true;
+            }
+
+            return false;
         }
 
         [HttpGet("orders-snapshot")]

--- a/OTS.Solution/OTS.Service/Interfaces/ILiveDealService.cs
+++ b/OTS.Solution/OTS.Service/Interfaces/ILiveDealService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using OTS.DOMAIN.MobileAccountingVM;
@@ -9,5 +10,6 @@ namespace OTS.Service.Interfaces
     {
         Task<LiveDealResultVM> GetLiveDealsAsync(DateOnly onDate, DateTime? sinceTime, string? symbol, string? action, int pageSize, bool asc, CancellationToken ct);
         Task<CrossTradePairResultVM> GetCrossTradePairsAsync(DateTime? fromTime, DateTime? toTime, CancellationToken ct);
+        Task<List<CrossTradePairDiffIpVM>> GetCrossTradePairsDiffIpAsync(DateTime? fromTime, DateTime? toTime, CancellationToken ct);
     }
 }

--- a/OTS.Solution/OTS.Service/LiveDealService.cs
+++ b/OTS.Solution/OTS.Service/LiveDealService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using MobileAccounting.Repositories.Interfaces;
@@ -24,6 +25,11 @@ namespace OTS.Service
         public Task<CrossTradePairResultVM> GetCrossTradePairsAsync(DateTime? fromTime, DateTime? toTime, CancellationToken ct)
         {
             return _repository.GetCrossTradePairsAsync(fromTime, toTime, ct);
+        }
+
+        public Task<List<CrossTradePairDiffIpVM>> GetCrossTradePairsDiffIpAsync(DateTime? fromTime, DateTime? toTime, CancellationToken ct)
+        {
+            return _repository.GetCrossTradePairsDiffIpAsync(fromTime, toTime, ct);
         }
     }
 }


### PR DESCRIPTION
## Summary
- add an optional `type` filter to the cross-trade pairs endpoint and branch to a DiffIP query
- expose repository and service methods to execute the new `usp_GetCrossTradePairs_DiffIP` stored procedure
- introduce a view model that maps the DiffIP result set columns

## Testing
- dotnet build OTS.Solution.sln *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f1c63d1e1c8330a814ea03b476a8b2