### PR TITLE
Add user management APIs

### DIFF
--- a/OTS.Solution/OTS.DOMAIN/MobileAccountingEntity/ApplicationUser.cs
+++ b/OTS.Solution/OTS.DOMAIN/MobileAccountingEntity/ApplicationUser.cs
@@ -6,5 +6,6 @@ namespace MobileAccounting.Entities
     {
         public int UserId { get; set; }
         public string? Role { get; set; }
+        public bool IsActive { get; set; }
     }
 }

--- a/OTS.Solution/OTS.DOMAIN/MobileAccountingVM/ManagerSummaryVM.cs
+++ b/OTS.Solution/OTS.DOMAIN/MobileAccountingVM/ManagerSummaryVM.cs
@@ -1,0 +1,13 @@
+using System.Text.Json.Serialization;
+
+namespace OTS.DOMAIN.MobileAccountingVM
+{
+    public class ManagerSummaryVM
+    {
+        [JsonPropertyName("managerId")]
+        public int ManagerId { get; set; }
+
+        [JsonPropertyName("managerName")]
+        public string ManagerName { get; set; } = string.Empty;
+    }
+}

--- a/OTS.Solution/OTS.DOMAIN/MobileAccountingVM/UserListItemVM.cs
+++ b/OTS.Solution/OTS.DOMAIN/MobileAccountingVM/UserListItemVM.cs
@@ -1,0 +1,14 @@
+namespace OTS.DOMAIN.MobileAccountingVM
+{
+    public class UserListItemVM
+    {
+        public string? UserName { get; set; }
+        public string? Email { get; set; }
+        public int UserId { get; set; }
+        public bool EmailConfirmed { get; set; }
+        public string? Role { get; set; }
+        public int? Head { get; set; }
+        public string? Id { get; set; }
+        public string? Status { get; set; }
+    }
+}

--- a/OTS.Solution/OTS.DOMAIN/MobileAccountingVM/UserManagerMappingRequestVM.cs
+++ b/OTS.Solution/OTS.DOMAIN/MobileAccountingVM/UserManagerMappingRequestVM.cs
@@ -8,5 +8,7 @@ namespace OTS.DOMAIN.MobileAccountingVM
 
         [Required]
         public string ManagerIds { get; set; } = string.Empty;
+
+        public string Action { get; set; } = "INSERT";
     }
 }

--- a/OTS.Solution/OTS.DOMAIN/MobileAccountingVM/UserManagerMappingRequestVM.cs
+++ b/OTS.Solution/OTS.DOMAIN/MobileAccountingVM/UserManagerMappingRequestVM.cs
@@ -1,0 +1,12 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace OTS.DOMAIN.MobileAccountingVM
+{
+    public class UserManagerMappingRequestVM
+    {
+        public int UserId { get; set; }
+
+        [Required]
+        public string ManagerIds { get; set; } = string.Empty;
+    }
+}

--- a/OTS.Solution/OTS.DOMAIN/MobileAccountingVM/UserManagerVM.cs
+++ b/OTS.Solution/OTS.DOMAIN/MobileAccountingVM/UserManagerVM.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace OTS.DOMAIN.MobileAccountingVM
+{
+    public class UserManagerVM
+    {
+        public int ManagerId { get; set; }
+
+        public int UserId { get; set; }
+
+        public string ManagerName { get; set; } = string.Empty;
+
+        public string UserName { get; set; } = string.Empty;
+
+        public string Email { get; set; } = string.Empty;
+
+        public string Role { get; set; } = string.Empty;
+
+        public string Status { get; set; } = string.Empty;
+    }
+}

--- a/OTS.Solution/OTS.DOMAIN/MobileAccountingVM/UserRequestVM.cs
+++ b/OTS.Solution/OTS.DOMAIN/MobileAccountingVM/UserRequestVM.cs
@@ -77,4 +77,16 @@ namespace OTS.DOMAIN.MobileAccountingVM
         public string? Role { get; set; }
         public bool IsActive { get; set; }
     }
+
+    public class UserListItemVM
+    {
+        public string? UserName { get; set; }
+        public string? Email { get; set; }
+        public int UserId { get; set; }
+        public bool EmailConfirmed { get; set; }
+        public string? Role { get; set; }
+        public int? Head { get; set; }
+        public string? Id { get; set; }
+        public string? Status { get; set; }
+    }
 }

--- a/OTS.Solution/OTS.DOMAIN/MobileAccountingVM/UserRequestVM.cs
+++ b/OTS.Solution/OTS.DOMAIN/MobileAccountingVM/UserRequestVM.cs
@@ -1,0 +1,80 @@
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace OTS.DOMAIN.MobileAccountingVM
+{
+    public class CreateUserRequestVM
+    {
+        [Required]
+        [MaxLength(256)]
+        public string UserName { get; set; } = string.Empty;
+
+        [Required]
+        [EmailAddress]
+        [MaxLength(256)]
+        public string Email { get; set; } = string.Empty;
+
+        [Required]
+        [MinLength(6)]
+        public string Password { get; set; } = string.Empty;
+
+        [MaxLength(128)]
+        public string? Role { get; set; }
+
+        public bool IsActive { get; set; } = true;
+    }
+
+    public class EditUserRequestVM
+    {
+        [Required]
+        [MaxLength(256)]
+        public string UserName { get; set; } = string.Empty;
+
+        [Required]
+        [EmailAddress]
+        [MaxLength(256)]
+        public string Email { get; set; } = string.Empty;
+
+        [MaxLength(128)]
+        public string? Role { get; set; }
+
+        public bool IsActive { get; set; } = true;
+    }
+
+    public class ChangePasswordRequestVM
+    {
+        [Required]
+        [MinLength(6)]
+        public string CurrentPassword { get; set; } = string.Empty;
+
+        [Required]
+        [MinLength(6)]
+        public string NewPassword { get; set; } = string.Empty;
+    }
+
+    public class ResetPasswordRequestVM
+    {
+        [Required]
+        [MinLength(6)]
+        public string NewPassword { get; set; } = string.Empty;
+    }
+
+    public class UserResponseVM
+    {
+        public bool IsSuccess { get; set; }
+        public bool IsNotFound { get; set; }
+        public string Message { get; set; } = string.Empty;
+        public IEnumerable<string> Errors { get; set; } = new List<string>();
+        public UserDetailsVM? Data { get; set; }
+    }
+
+    public class UserDetailsVM
+    {
+        public string? Id { get; set; }
+        public int UserId { get; set; }
+        public string? UserName { get; set; }
+        public string? Email { get; set; }
+        public string? Role { get; set; }
+        public bool IsActive { get; set; }
+    }
+}

--- a/OTS.Solution/OTS.DOMAIN/MobileAccountingVM/UserRequestVM.cs
+++ b/OTS.Solution/OTS.DOMAIN/MobileAccountingVM/UserRequestVM.cs
@@ -78,15 +78,4 @@ namespace OTS.DOMAIN.MobileAccountingVM
         public bool IsActive { get; set; }
     }
 
-    public class UserListItemVM
-    {
-        public string? UserName { get; set; }
-        public string? Email { get; set; }
-        public int UserId { get; set; }
-        public bool EmailConfirmed { get; set; }
-        public string? Role { get; set; }
-        public int? Head { get; set; }
-        public string? Id { get; set; }
-        public string? Status { get; set; }
-    }
 }

--- a/OTS.Solution/OTS.Infrastructutre/MobileRepository/Implementations/LiveDealRepository.cs
+++ b/OTS.Solution/OTS.Infrastructutre/MobileRepository/Implementations/LiveDealRepository.cs
@@ -25,6 +25,7 @@ namespace MobileAccounting.Repositories.Implementations
                 new DbParameter("Symbol", ParameterDirection.Input, symbol),
                 new DbParameter("Action", ParameterDirection.Input, action),
                 new DbParameter("PageSize", ParameterDirection.Input, pageSize),
+                // Restrict the result set to the requested user when executing usp_GetLiveDeals
                 new DbParameter("UserId", ParameterDirection.Input, userId)
             };
 

--- a/OTS.Solution/OTS.Infrastructutre/MobileRepository/Implementations/LiveDealRepository.cs
+++ b/OTS.Solution/OTS.Infrastructutre/MobileRepository/Implementations/LiveDealRepository.cs
@@ -16,7 +16,7 @@ namespace MobileAccounting.Repositories.Implementations
             _db = db;
         }
 
-        public async Task<LiveDealResultVM> GetLiveDealsAsync(DateOnly onDate, DateTime? sinceTime, string? symbol, string? action, int pageSize, bool asc, CancellationToken ct)
+        public async Task<LiveDealResultVM> GetLiveDealsAsync(DateOnly onDate, DateTime? sinceTime, string? symbol, string? action, int pageSize, bool asc, int userId, CancellationToken ct)
         {
             var parameters = new List<DbParameter>
             {
@@ -24,7 +24,8 @@ namespace MobileAccounting.Repositories.Implementations
                 new DbParameter("SinceTime", ParameterDirection.Input, sinceTime),
                 new DbParameter("Symbol", ParameterDirection.Input, symbol),
                 new DbParameter("Action", ParameterDirection.Input, action),
-                new DbParameter("PageSize", ParameterDirection.Input, pageSize)
+                new DbParameter("PageSize", ParameterDirection.Input, pageSize),
+                new DbParameter("UserId", ParameterDirection.Input, userId)
             };
 
             var (rows, meta) = await _db.ExecuteMultipleAsync<LiveDealVM, LiveDealMetaVM>("usp_GetLiveDeals", parameters);

--- a/OTS.Solution/OTS.Infrastructutre/MobileRepository/Implementations/OrderSnapshotRepository.cs
+++ b/OTS.Solution/OTS.Infrastructutre/MobileRepository/Implementations/OrderSnapshotRepository.cs
@@ -18,17 +18,19 @@ namespace MobileAccounting.Repositories.Implementations
             _db = db;
         }
 
-        public async Task<OrderSnapshotResultVM> GetOrdersSnapshotAsync(string? symbol, long? orderId, int? top, CancellationToken ct)
+        public async Task<OrderSnapshotResultVM> GetOrdersSnapshotAsync(string? symbol, long? orderId, int? top, int userId, CancellationToken ct)
         {
             var parameters = new List<DbParameter>
             {
                 new DbParameter("Symbol", ParameterDirection.Input, symbol ?? (object)DBNull.Value),
                 new DbParameter("OrderId", ParameterDirection.Input, orderId ?? (object)DBNull.Value),
-                new DbParameter("Top", ParameterDirection.Input, top ?? (object)DBNull.Value)
+                new DbParameter("Top", ParameterDirection.Input, top ?? (object)DBNull.Value),
+                new DbParameter("UserId", ParameterDirection.Input, userId)
             };
 
             var (rows, meta) = await _db.ExecuteMultipleAsync<OrderSnapshotVM, OrderSnapshotMetaVM>(
-                "usp_GetOrdersSnapshot", parameters);
+                "usp_GetOrdersSnapshot",
+                parameters);
 
             return new OrderSnapshotResultVM
             {

--- a/OTS.Solution/OTS.Infrastructutre/MobileRepository/Interfaces/ILiveDealRepository.cs
+++ b/OTS.Solution/OTS.Infrastructutre/MobileRepository/Interfaces/ILiveDealRepository.cs
@@ -8,7 +8,7 @@ namespace MobileAccounting.Repositories.Interfaces
 {
     public interface ILiveDealRepository
     {
-        Task<LiveDealResultVM> GetLiveDealsAsync(DateOnly onDate, DateTime? sinceTime, string? symbol, string? action, int pageSize, bool asc, CancellationToken ct);
+        Task<LiveDealResultVM> GetLiveDealsAsync(DateOnly onDate, DateTime? sinceTime, string? symbol, string? action, int pageSize, bool asc, int userId, CancellationToken ct);
         Task<CrossTradePairResultVM> GetCrossTradePairsAsync(DateTime? fromTime, DateTime? toTime, CancellationToken ct);
         Task<List<CrossTradePairDiffIpVM>> GetCrossTradePairsDiffIpAsync(DateTime? fromTime, DateTime? toTime, CancellationToken ct);
     }

--- a/OTS.Solution/OTS.Infrastructutre/MobileRepository/Interfaces/IOrderSnapshotRepository.cs
+++ b/OTS.Solution/OTS.Infrastructutre/MobileRepository/Interfaces/IOrderSnapshotRepository.cs
@@ -7,6 +7,11 @@ namespace MobileAccounting.Repositories.Interfaces
 {
     public interface IOrderSnapshotRepository
     {
-        Task<OrderSnapshotResultVM> GetOrdersSnapshotAsync(string? symbol, long? orderId, int? top, CancellationToken ct);
+        Task<OrderSnapshotResultVM> GetOrdersSnapshotAsync(
+            string? symbol,
+            long? orderId,
+            int? top,
+            int userId,
+            CancellationToken ct);
     }
 }

--- a/OTS.Solution/OTS.MobileAccountingAPI/Controllers/DealsController.cs
+++ b/OTS.Solution/OTS.MobileAccountingAPI/Controllers/DealsController.cs
@@ -132,9 +132,15 @@ namespace OTS.MobileAccountingAPI.Controllers
             [FromQuery] string? symbol,
             [FromQuery] long? orderId,
             [FromQuery] int? top,
+            [FromQuery(Name = "userId")] int? userId,
             CancellationToken ct = default)
         {
-            var result = await _orderSnapshotService.GetOrdersSnapshotAsync(symbol, orderId, top, ct);
+            if (!TryResolveUserId(userId, out var effectiveUserId))
+            {
+                return Unauthorized();
+            }
+
+            var result = await _orderSnapshotService.GetOrdersSnapshotAsync(symbol, orderId, top, effectiveUserId, ct);
             return Ok(new { rows = result.Rows, maxTime = result.MaxTime, rowCount = result.TotalRows });
         }
 

--- a/OTS.Solution/OTS.MobileAccountingAPI/Controllers/UsersController.cs
+++ b/OTS.Solution/OTS.MobileAccountingAPI/Controllers/UsersController.cs
@@ -1,0 +1,119 @@
+using System.Linq;
+using Microsoft.AspNetCore.Mvc;
+using OTS.DOMAIN.MobileAccountingVM;
+using OTS.Service.Interfaces;
+
+namespace OTS.MobileAccountingAPI.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class UsersController : ControllerBase
+    {
+        private readonly IUserService _userService;
+
+        public UsersController(IUserService userService)
+        {
+            _userService = userService;
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> CreateUser([FromBody] CreateUserRequestVM request)
+        {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelStateErrorsResponse("Invalid user data."));
+            }
+
+            var response = await _userService.CreateUserAsync(request);
+            if (!response.IsSuccess)
+            {
+                return BadRequest(response);
+            }
+
+            return Ok(response);
+        }
+
+        [HttpPut("{id}")]
+        public async Task<IActionResult> UpdateUser(string id, [FromBody] EditUserRequestVM request)
+        {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelStateErrorsResponse("Invalid user data."));
+            }
+
+            var response = await _userService.UpdateUserAsync(id, request);
+            if (response.IsNotFound)
+            {
+                return NotFound(response);
+            }
+
+            if (!response.IsSuccess)
+            {
+                return BadRequest(response);
+            }
+
+            return Ok(response);
+        }
+
+        [HttpPost("{id}/change-password")]
+        public async Task<IActionResult> ChangePassword(string id, [FromBody] ChangePasswordRequestVM request)
+        {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelStateErrorsResponse("Invalid password change request."));
+            }
+
+            var response = await _userService.ChangePasswordAsync(id, request);
+            if (response.IsNotFound)
+            {
+                return NotFound(response);
+            }
+
+            if (!response.IsSuccess)
+            {
+                return BadRequest(response);
+            }
+
+            return Ok(response);
+        }
+
+        [HttpPost("{id}/reset-password")]
+        public async Task<IActionResult> ResetPassword(string id, [FromBody] ResetPasswordRequestVM request)
+        {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelStateErrorsResponse("Invalid password reset request."));
+            }
+
+            var response = await _userService.ResetPasswordAsync(id, request);
+            if (response.IsNotFound)
+            {
+                return NotFound(response);
+            }
+
+            if (!response.IsSuccess)
+            {
+                return BadRequest(response);
+            }
+
+            return Ok(response);
+        }
+
+        private UserResponseVM ModelStateErrorsResponse(string message)
+        {
+            var errors = ModelState.Values
+                .SelectMany(v => v.Errors)
+                .Select(e => string.IsNullOrWhiteSpace(e.ErrorMessage) ? e.Exception?.Message : e.ErrorMessage)
+                .Where(e => !string.IsNullOrWhiteSpace(e))
+                .Cast<string>()
+                .ToList();
+
+            return new UserResponseVM
+            {
+                IsSuccess = false,
+                Message = message,
+                Errors = errors
+            };
+        }
+    }
+}

--- a/OTS.Solution/OTS.MobileAccountingAPI/Controllers/UsersController.cs
+++ b/OTS.Solution/OTS.MobileAccountingAPI/Controllers/UsersController.cs
@@ -132,7 +132,7 @@ namespace OTS.MobileAccountingAPI.Controllers
         }
 
         [HttpGet("{userId:int}/managers")]
-        public async Task<ActionResult<IEnumerable<UserManagerVM>>> GetUserManagers(int userId)
+        public async Task<ActionResult<IEnumerable<ManagerSummaryVM>>> GetUserManagers(int userId)
         {
             var managers = await _userService.GetManagersByUserIdAsync(userId);
             return Ok(managers);

--- a/OTS.Solution/OTS.MobileAccountingAPI/Controllers/UsersController.cs
+++ b/OTS.Solution/OTS.MobileAccountingAPI/Controllers/UsersController.cs
@@ -131,6 +131,13 @@ namespace OTS.MobileAccountingAPI.Controllers
             return Ok(response);
         }
 
+        [HttpGet("{userId:int}/managers")]
+        public async Task<ActionResult<IEnumerable<UserManagerVM>>> GetUserManagers(int userId)
+        {
+            var managers = await _userService.GetManagersByUserIdAsync(userId);
+            return Ok(managers);
+        }
+
         private UserResponseVM ModelStateErrorsResponse(string message)
         {
             var errors = ModelState.Values

--- a/OTS.Solution/OTS.MobileAccountingAPI/Controllers/UsersController.cs
+++ b/OTS.Solution/OTS.MobileAccountingAPI/Controllers/UsersController.cs
@@ -1,4 +1,6 @@
+using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using OTS.DOMAIN.MobileAccountingVM;
 using OTS.Service.Interfaces;
@@ -14,6 +16,13 @@ namespace OTS.MobileAccountingAPI.Controllers
         public UsersController(IUserService userService)
         {
             _userService = userService;
+        }
+
+        [HttpGet]
+        public async Task<ActionResult<IEnumerable<UserListItemVM>>> GetUsers([FromQuery] string? role, [FromQuery] bool? isActive)
+        {
+            var users = await _userService.GetUserListAsync(role, isActive);
+            return Ok(users);
         }
 
         [HttpPost]

--- a/OTS.Solution/OTS.MobileAccountingAPI/Controllers/UsersController.cs
+++ b/OTS.Solution/OTS.MobileAccountingAPI/Controllers/UsersController.cs
@@ -108,6 +108,29 @@ namespace OTS.MobileAccountingAPI.Controllers
             return Ok(response);
         }
 
+        [HttpPost("{userId:int}/manager-mapping")]
+        public async Task<IActionResult> SetUserManagerMapping(int userId, [FromBody] UserManagerMappingRequestVM request)
+        {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelStateErrorsResponse("Invalid manager mapping data."));
+            }
+
+            request.UserId = userId;
+            var response = await _userService.SetUserManagerMappingAsync(request);
+            if (response.IsNotFound)
+            {
+                return NotFound(response);
+            }
+
+            if (!response.IsSuccess)
+            {
+                return BadRequest(response);
+            }
+
+            return Ok(response);
+        }
+
         private UserResponseVM ModelStateErrorsResponse(string message)
         {
             var errors = ModelState.Values

--- a/OTS.Solution/OTS.Service/DependencyInjection.cs
+++ b/OTS.Solution/OTS.Service/DependencyInjection.cs
@@ -60,6 +60,7 @@ namespace OTS.Service
             services.AddScoped<ILiveSummaryService, LiveSummaryService>();
             services.AddScoped<IDealHistoryService, DealHistoryService>();
             services.AddScoped<IMasterService, MasterService>();
+            services.AddScoped<IUserService, UserService>();
 
             return services;
         }

--- a/OTS.Solution/OTS.Service/Interfaces/ILiveDealService.cs
+++ b/OTS.Solution/OTS.Service/Interfaces/ILiveDealService.cs
@@ -8,7 +8,7 @@ namespace OTS.Service.Interfaces
 {
     public interface ILiveDealService
     {
-        Task<LiveDealResultVM> GetLiveDealsAsync(DateOnly onDate, DateTime? sinceTime, string? symbol, string? action, int pageSize, bool asc, CancellationToken ct);
+        Task<LiveDealResultVM> GetLiveDealsAsync(DateOnly onDate, DateTime? sinceTime, string? symbol, string? action, int pageSize, bool asc, int userId, CancellationToken ct);
         Task<CrossTradePairResultVM> GetCrossTradePairsAsync(DateTime? fromTime, DateTime? toTime, CancellationToken ct);
         Task<List<CrossTradePairDiffIpVM>> GetCrossTradePairsDiffIpAsync(DateTime? fromTime, DateTime? toTime, CancellationToken ct);
     }

--- a/OTS.Solution/OTS.Service/Interfaces/ILiveDealService.cs
+++ b/OTS.Solution/OTS.Service/Interfaces/ILiveDealService.cs
@@ -8,6 +8,17 @@ namespace OTS.Service.Interfaces
 {
     public interface ILiveDealService
     {
+        /// <summary>
+        /// Retrieves paged live deals for the supplied filters and restricts the result set to the specified user.
+        /// </summary>
+        /// <param name="onDate">Trading date to evaluate.</param>
+        /// <param name="sinceTime">Optional cursor for incremental fetches.</param>
+        /// <param name="symbol">Optional symbol filter.</param>
+        /// <param name="action">Optional action filter.</param>
+        /// <param name="pageSize">Number of rows to return.</param>
+        /// <param name="asc">Whether rows should be sorted ascending.</param>
+        /// <param name="userId">The user whose data should be returned.</param>
+        /// <param name="ct">Cancellation token.</param>
         Task<LiveDealResultVM> GetLiveDealsAsync(DateOnly onDate, DateTime? sinceTime, string? symbol, string? action, int pageSize, bool asc, int userId, CancellationToken ct);
         Task<CrossTradePairResultVM> GetCrossTradePairsAsync(DateTime? fromTime, DateTime? toTime, CancellationToken ct);
         Task<List<CrossTradePairDiffIpVM>> GetCrossTradePairsDiffIpAsync(DateTime? fromTime, DateTime? toTime, CancellationToken ct);

--- a/OTS.Solution/OTS.Service/Interfaces/IOrderSnapshotService.cs
+++ b/OTS.Solution/OTS.Service/Interfaces/IOrderSnapshotService.cs
@@ -7,6 +7,11 @@ namespace OTS.Service.Interfaces
 {
     public interface IOrderSnapshotService
     {
-        Task<OrderSnapshotResultVM> GetOrdersSnapshotAsync(string? symbol, long? orderId, int? top, CancellationToken ct);
+        Task<OrderSnapshotResultVM> GetOrdersSnapshotAsync(
+            string? symbol,
+            long? orderId,
+            int? top,
+            int userId,
+            CancellationToken ct);
     }
 }

--- a/OTS.Solution/OTS.Service/Interfaces/IUserService.cs
+++ b/OTS.Solution/OTS.Service/Interfaces/IUserService.cs
@@ -12,5 +12,6 @@ namespace OTS.Service.Interfaces
         Task<UserResponseVM> ResetPasswordAsync(string id, ResetPasswordRequestVM request);
         Task<IEnumerable<UserListItemVM>> GetUserListAsync(string? role, bool? isActive);
         Task<UserResponseVM> SetUserManagerMappingAsync(UserManagerMappingRequestVM request);
+        Task<IEnumerable<UserManagerVM>> GetManagersByUserIdAsync(int userId);
     }
 }

--- a/OTS.Solution/OTS.Service/Interfaces/IUserService.cs
+++ b/OTS.Solution/OTS.Service/Interfaces/IUserService.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using OTS.DOMAIN.MobileAccountingVM;
 
@@ -9,5 +10,6 @@ namespace OTS.Service.Interfaces
         Task<UserResponseVM> UpdateUserAsync(string id, EditUserRequestVM request);
         Task<UserResponseVM> ChangePasswordAsync(string id, ChangePasswordRequestVM request);
         Task<UserResponseVM> ResetPasswordAsync(string id, ResetPasswordRequestVM request);
+        Task<IEnumerable<UserListItemVM>> GetUserListAsync(string? role, bool? isActive);
     }
 }

--- a/OTS.Solution/OTS.Service/Interfaces/IUserService.cs
+++ b/OTS.Solution/OTS.Service/Interfaces/IUserService.cs
@@ -11,5 +11,6 @@ namespace OTS.Service.Interfaces
         Task<UserResponseVM> ChangePasswordAsync(string id, ChangePasswordRequestVM request);
         Task<UserResponseVM> ResetPasswordAsync(string id, ResetPasswordRequestVM request);
         Task<IEnumerable<UserListItemVM>> GetUserListAsync(string? role, bool? isActive);
+        Task<UserResponseVM> SetUserManagerMappingAsync(UserManagerMappingRequestVM request);
     }
 }

--- a/OTS.Solution/OTS.Service/Interfaces/IUserService.cs
+++ b/OTS.Solution/OTS.Service/Interfaces/IUserService.cs
@@ -12,6 +12,6 @@ namespace OTS.Service.Interfaces
         Task<UserResponseVM> ResetPasswordAsync(string id, ResetPasswordRequestVM request);
         Task<IEnumerable<UserListItemVM>> GetUserListAsync(string? role, bool? isActive);
         Task<UserResponseVM> SetUserManagerMappingAsync(UserManagerMappingRequestVM request);
-        Task<IEnumerable<UserManagerVM>> GetManagersByUserIdAsync(int userId);
+        Task<IEnumerable<ManagerSummaryVM>> GetManagersByUserIdAsync(int userId);
     }
 }

--- a/OTS.Solution/OTS.Service/Interfaces/IUserService.cs
+++ b/OTS.Solution/OTS.Service/Interfaces/IUserService.cs
@@ -1,0 +1,13 @@
+using System.Threading.Tasks;
+using OTS.DOMAIN.MobileAccountingVM;
+
+namespace OTS.Service.Interfaces
+{
+    public interface IUserService
+    {
+        Task<UserResponseVM> CreateUserAsync(CreateUserRequestVM request);
+        Task<UserResponseVM> UpdateUserAsync(string id, EditUserRequestVM request);
+        Task<UserResponseVM> ChangePasswordAsync(string id, ChangePasswordRequestVM request);
+        Task<UserResponseVM> ResetPasswordAsync(string id, ResetPasswordRequestVM request);
+    }
+}

--- a/OTS.Solution/OTS.Service/LiveDealService.cs
+++ b/OTS.Solution/OTS.Service/LiveDealService.cs
@@ -17,9 +17,9 @@ namespace OTS.Service
             _repository = repository;
         }
 
-        public Task<LiveDealResultVM> GetLiveDealsAsync(DateOnly onDate, DateTime? sinceTime, string? symbol, string? action, int pageSize, bool asc, CancellationToken ct)
+        public Task<LiveDealResultVM> GetLiveDealsAsync(DateOnly onDate, DateTime? sinceTime, string? symbol, string? action, int pageSize, bool asc, int userId, CancellationToken ct)
         {
-            return _repository.GetLiveDealsAsync(onDate, sinceTime, symbol, action, pageSize, asc, ct);
+            return _repository.GetLiveDealsAsync(onDate, sinceTime, symbol, action, pageSize, asc, userId, ct);
         }
 
         public Task<CrossTradePairResultVM> GetCrossTradePairsAsync(DateTime? fromTime, DateTime? toTime, CancellationToken ct)

--- a/OTS.Solution/OTS.Service/OrderSnapshotService.cs
+++ b/OTS.Solution/OTS.Service/OrderSnapshotService.cs
@@ -16,9 +16,9 @@ namespace OTS.Service
             _repository = repository;
         }
 
-        public Task<OrderSnapshotResultVM> GetOrdersSnapshotAsync(string? symbol, long? orderId, int? top, CancellationToken ct)
+        public Task<OrderSnapshotResultVM> GetOrdersSnapshotAsync(string? symbol, long? orderId, int? top, int userId, CancellationToken ct)
         {
-            return _repository.GetOrdersSnapshotAsync(symbol, orderId, top, ct);
+            return _repository.GetOrdersSnapshotAsync(symbol, orderId, top, userId, ct);
         }
     }
 }

--- a/OTS.Solution/OTS.Service/UserService.cs
+++ b/OTS.Solution/OTS.Service/UserService.cs
@@ -152,6 +152,25 @@ namespace OTS.Service
             return users;
         }
 
+        public async Task<UserResponseVM> SetUserManagerMappingAsync(UserManagerMappingRequestVM request)
+        {
+            var user = await _userManager.Users.FirstOrDefaultAsync(u => u.UserId == request.UserId);
+            if (user == null)
+            {
+                return BuildNotFoundResponse();
+            }
+
+            var parameters = new List<DbParameter>
+            {
+                new DbParameter("UserId", ParameterDirection.Input, request.UserId),
+                new DbParameter("ManagerIds", ParameterDirection.Input, request.ManagerIds)
+            };
+
+            await _dbManager.ExecuteNonQueryAsync("usp_InsertUserManagerMapping", parameters);
+
+            return BuildSuccessResponse("User manager mapping saved successfully.", user);
+        }
+
         private async Task<int> GetNextUserIdAsync()
         {
             var maxIdentityId = 0;

--- a/OTS.Solution/OTS.Service/UserService.cs
+++ b/OTS.Solution/OTS.Service/UserService.cs
@@ -1,0 +1,256 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using MobileAccounting.Entities;
+using OTS.DOMAIN.Database;
+using OTS.DOMAIN.MobileAccountingVM;
+using OTS.Service.Interfaces;
+
+namespace OTS.Service
+{
+    public class UserService : IUserService
+    {
+        private readonly UserManager<ApplicationUser> _userManager;
+        private readonly AccountingDbContext _dbContext;
+
+        public UserService(UserManager<ApplicationUser> userManager, AccountingDbContext dbContext)
+        {
+            _userManager = userManager;
+            _dbContext = dbContext;
+        }
+
+        public async Task<UserResponseVM> CreateUserAsync(CreateUserRequestVM request)
+        {
+            var existingByName = await _userManager.FindByNameAsync(request.UserName);
+            if (existingByName != null)
+            {
+                return BuildFailureResponse("Username already exists.");
+            }
+
+            var existingByEmail = await _userManager.FindByEmailAsync(request.Email);
+            if (existingByEmail != null)
+            {
+                return BuildFailureResponse("Email already exists.");
+            }
+
+            var identityUser = new ApplicationUser
+            {
+                UserName = request.UserName,
+                Email = request.Email,
+                Role = request.Role,
+                IsActive = request.IsActive,
+                LockoutEnabled = !request.IsActive
+            };
+
+            if (!request.IsActive)
+            {
+                identityUser.LockoutEnd = DateTimeOffset.MaxValue;
+            }
+
+            identityUser.UserId = await GetNextUserIdAsync();
+
+            var creationResult = await _userManager.CreateAsync(identityUser, request.Password);
+            if (!creationResult.Succeeded)
+            {
+                return BuildFailureResponse("Unable to create user.", creationResult.Errors);
+            }
+
+            await CreateUserEntityAsync(identityUser);
+
+            return BuildSuccessResponse("User created successfully.", identityUser);
+        }
+
+        public async Task<UserResponseVM> UpdateUserAsync(string id, EditUserRequestVM request)
+        {
+            var user = await _userManager.FindByIdAsync(id);
+            if (user == null)
+            {
+                return BuildNotFoundResponse();
+            }
+
+            if (!string.Equals(user.UserName, request.UserName, StringComparison.OrdinalIgnoreCase))
+            {
+                var existingByName = await _userManager.FindByNameAsync(request.UserName);
+                if (existingByName != null && existingByName.Id != user.Id)
+                {
+                    return BuildFailureResponse("Username already exists.");
+                }
+            }
+
+            if (!string.Equals(user.Email, request.Email, StringComparison.OrdinalIgnoreCase))
+            {
+                var existingByEmail = await _userManager.FindByEmailAsync(request.Email);
+                if (existingByEmail != null && existingByEmail.Id != user.Id)
+                {
+                    return BuildFailureResponse("Email already exists.");
+                }
+            }
+
+            user.UserName = request.UserName;
+            user.Email = request.Email;
+            user.Role = request.Role;
+            user.IsActive = request.IsActive;
+            user.LockoutEnabled = !request.IsActive;
+            user.LockoutEnd = request.IsActive ? null : DateTimeOffset.MaxValue;
+
+            var updateResult = await _userManager.UpdateAsync(user);
+            if (!updateResult.Succeeded)
+            {
+                return BuildFailureResponse("Unable to update user.", updateResult.Errors);
+            }
+
+            await UpdateUserEntityAsync(user, updatePassword: false);
+
+            return BuildSuccessResponse("User updated successfully.", user);
+        }
+
+        public async Task<UserResponseVM> ChangePasswordAsync(string id, ChangePasswordRequestVM request)
+        {
+            var user = await _userManager.FindByIdAsync(id);
+            if (user == null)
+            {
+                return BuildNotFoundResponse();
+            }
+
+            var changeResult = await _userManager.ChangePasswordAsync(user, request.CurrentPassword, request.NewPassword);
+            if (!changeResult.Succeeded)
+            {
+                return BuildFailureResponse("Unable to change password.", changeResult.Errors);
+            }
+
+            await _userManager.UpdateSecurityStampAsync(user);
+            await UpdateUserEntityAsync(user, updatePassword: true);
+
+            return BuildSuccessResponse("Password changed successfully.", user, includeDetails: false);
+        }
+
+        public async Task<UserResponseVM> ResetPasswordAsync(string id, ResetPasswordRequestVM request)
+        {
+            var user = await _userManager.FindByIdAsync(id);
+            if (user == null)
+            {
+                return BuildNotFoundResponse();
+            }
+
+            var token = await _userManager.GeneratePasswordResetTokenAsync(user);
+            var resetResult = await _userManager.ResetPasswordAsync(user, token, request.NewPassword);
+            if (!resetResult.Succeeded)
+            {
+                return BuildFailureResponse("Unable to reset password.", resetResult.Errors);
+            }
+
+            await _userManager.UpdateSecurityStampAsync(user);
+            await UpdateUserEntityAsync(user, updatePassword: true);
+
+            return BuildSuccessResponse("Password reset successfully.", user, includeDetails: false);
+        }
+
+        private async Task<int> GetNextUserIdAsync()
+        {
+            var maxIdentityId = 0;
+            if (await _userManager.Users.AnyAsync())
+            {
+                maxIdentityId = await _userManager.Users.MaxAsync(u => u.UserId);
+            }
+
+            var maxUserEntityId = 0;
+            if (await _dbContext.Users.AnyAsync())
+            {
+                maxUserEntityId = await _dbContext.Users.MaxAsync(u => u.UserId);
+            }
+
+            return Math.Max(maxIdentityId, maxUserEntityId) + 1;
+        }
+
+        private async Task CreateUserEntityAsync(ApplicationUser identityUser)
+        {
+            var existingEntity = await _dbContext.Users.FirstOrDefaultAsync(u => u.UserId == identityUser.UserId);
+            if (existingEntity != null)
+            {
+                await UpdateUserEntityAsync(identityUser, updatePassword: true);
+                return;
+            }
+
+            var entity = new User
+            {
+                UserId = identityUser.UserId,
+                Username = identityUser.UserName ?? string.Empty,
+                Email = identityUser.Email ?? string.Empty,
+                PasswordHash = identityUser.PasswordHash ?? string.Empty,
+                Role = identityUser.Role ?? string.Empty,
+                IsActive = identityUser.IsActive,
+                CreatedAt = DateTime.UtcNow
+            };
+
+            await _dbContext.Users.AddAsync(entity);
+            await _dbContext.SaveChangesAsync();
+        }
+
+        private async Task UpdateUserEntityAsync(ApplicationUser identityUser, bool updatePassword)
+        {
+            var entity = await _dbContext.Users.FirstOrDefaultAsync(u => u.UserId == identityUser.UserId);
+            if (entity == null)
+            {
+                entity = new User
+                {
+                    UserId = identityUser.UserId,
+                    CreatedAt = DateTime.UtcNow
+                };
+                await _dbContext.Users.AddAsync(entity);
+            }
+
+            entity.Username = identityUser.UserName ?? string.Empty;
+            entity.Email = identityUser.Email ?? string.Empty;
+            entity.Role = identityUser.Role ?? string.Empty;
+            entity.IsActive = identityUser.IsActive;
+            if (updatePassword || string.IsNullOrEmpty(entity.PasswordHash))
+            {
+                entity.PasswordHash = identityUser.PasswordHash ?? string.Empty;
+            }
+
+            await _dbContext.SaveChangesAsync();
+        }
+
+        private static UserResponseVM BuildSuccessResponse(string message, ApplicationUser user, bool includeDetails = true)
+        {
+            return new UserResponseVM
+            {
+                IsSuccess = true,
+                Message = message,
+                Data = includeDetails ? new UserDetailsVM
+                {
+                    Id = user.Id,
+                    UserId = user.UserId,
+                    UserName = user.UserName,
+                    Email = user.Email,
+                    Role = user.Role,
+                    IsActive = user.IsActive
+                } : null
+            };
+        }
+
+        private static UserResponseVM BuildFailureResponse(string message, IEnumerable<IdentityError>? errors = null)
+        {
+            return new UserResponseVM
+            {
+                IsSuccess = false,
+                Message = message,
+                Errors = errors?.Select(e => e.Description).Where(e => !string.IsNullOrWhiteSpace(e)).ToList()
+                         ?? new List<string>()
+            };
+        }
+
+        private static UserResponseVM BuildNotFoundResponse()
+        {
+            return new UserResponseVM
+            {
+                IsSuccess = false,
+                IsNotFound = true,
+                Message = "User not found."
+            };
+        }
+    }
+}

--- a/OTS.Solution/OTS.Service/UserService.cs
+++ b/OTS.Solution/OTS.Service/UserService.cs
@@ -174,6 +174,17 @@ namespace OTS.Service
             return BuildSuccessResponse("User manager mapping saved successfully.", user);
         }
 
+        public async Task<IEnumerable<UserManagerVM>> GetManagersByUserIdAsync(int userId)
+        {
+            var parameters = new List<DbParameter>
+            {
+                new DbParameter("UserId", ParameterDirection.Input, userId)
+            };
+
+            var managers = await _dbManager.ExecuteListAsync<UserManagerVM>("usp_GetManagersByUserId", parameters);
+            return managers;
+        }
+
         private async Task<int> GetNextUserIdAsync()
         {
             var maxIdentityId = 0;

--- a/OTS.Solution/OTS.Service/UserService.cs
+++ b/OTS.Solution/OTS.Service/UserService.cs
@@ -4,8 +4,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
-using MobileAccounting.Entities;
-using OTS.DOMAIN.Database;
 using OTS.DOMAIN.MobileAccountingVM;
 using OTS.Service.Interfaces;
 
@@ -14,12 +12,9 @@ namespace OTS.Service
     public class UserService : IUserService
     {
         private readonly UserManager<ApplicationUser> _userManager;
-        private readonly AccountingDbContext _dbContext;
-
-        public UserService(UserManager<ApplicationUser> userManager, AccountingDbContext dbContext)
+        public UserService(UserManager<ApplicationUser> userManager)
         {
             _userManager = userManager;
-            _dbContext = dbContext;
         }
 
         public async Task<UserResponseVM> CreateUserAsync(CreateUserRequestVM request)
@@ -57,8 +52,6 @@ namespace OTS.Service
             {
                 return BuildFailureResponse("Unable to create user.", creationResult.Errors);
             }
-
-            await CreateUserEntityAsync(identityUser);
 
             return BuildSuccessResponse("User created successfully.", identityUser);
         }
@@ -101,9 +94,6 @@ namespace OTS.Service
             {
                 return BuildFailureResponse("Unable to update user.", updateResult.Errors);
             }
-
-            await UpdateUserEntityAsync(user, updatePassword: false);
-
             return BuildSuccessResponse("User updated successfully.", user);
         }
 
@@ -122,8 +112,6 @@ namespace OTS.Service
             }
 
             await _userManager.UpdateSecurityStampAsync(user);
-            await UpdateUserEntityAsync(user, updatePassword: true);
-
             return BuildSuccessResponse("Password changed successfully.", user, includeDetails: false);
         }
 
@@ -143,8 +131,6 @@ namespace OTS.Service
             }
 
             await _userManager.UpdateSecurityStampAsync(user);
-            await UpdateUserEntityAsync(user, updatePassword: true);
-
             return BuildSuccessResponse("Password reset successfully.", user, includeDetails: false);
         }
 
@@ -155,63 +141,7 @@ namespace OTS.Service
             {
                 maxIdentityId = await _userManager.Users.MaxAsync(u => u.UserId);
             }
-
-            var maxUserEntityId = 0;
-            if (await _dbContext.Users.AnyAsync())
-            {
-                maxUserEntityId = await _dbContext.Users.MaxAsync(u => u.UserId);
-            }
-
-            return Math.Max(maxIdentityId, maxUserEntityId) + 1;
-        }
-
-        private async Task CreateUserEntityAsync(ApplicationUser identityUser)
-        {
-            var existingEntity = await _dbContext.Users.FirstOrDefaultAsync(u => u.UserId == identityUser.UserId);
-            if (existingEntity != null)
-            {
-                await UpdateUserEntityAsync(identityUser, updatePassword: true);
-                return;
-            }
-
-            var entity = new User
-            {
-                UserId = identityUser.UserId,
-                Username = identityUser.UserName ?? string.Empty,
-                Email = identityUser.Email ?? string.Empty,
-                PasswordHash = identityUser.PasswordHash ?? string.Empty,
-                Role = identityUser.Role ?? string.Empty,
-                IsActive = identityUser.IsActive,
-                CreatedAt = DateTime.UtcNow
-            };
-
-            await _dbContext.Users.AddAsync(entity);
-            await _dbContext.SaveChangesAsync();
-        }
-
-        private async Task UpdateUserEntityAsync(ApplicationUser identityUser, bool updatePassword)
-        {
-            var entity = await _dbContext.Users.FirstOrDefaultAsync(u => u.UserId == identityUser.UserId);
-            if (entity == null)
-            {
-                entity = new User
-                {
-                    UserId = identityUser.UserId,
-                    CreatedAt = DateTime.UtcNow
-                };
-                await _dbContext.Users.AddAsync(entity);
-            }
-
-            entity.Username = identityUser.UserName ?? string.Empty;
-            entity.Email = identityUser.Email ?? string.Empty;
-            entity.Role = identityUser.Role ?? string.Empty;
-            entity.IsActive = identityUser.IsActive;
-            if (updatePassword || string.IsNullOrEmpty(entity.PasswordHash))
-            {
-                entity.PasswordHash = identityUser.PasswordHash ?? string.Empty;
-            }
-
-            await _dbContext.SaveChangesAsync();
+            return maxIdentityId + 1;
         }
 
         private static UserResponseVM BuildSuccessResponse(string message, ApplicationUser user, bool includeDetails = true)

--- a/OTS.Solution/OTS.Service/UserService.cs
+++ b/OTS.Solution/OTS.Service/UserService.cs
@@ -174,14 +174,14 @@ namespace OTS.Service
             return BuildSuccessResponse("User manager mapping saved successfully.", user);
         }
 
-        public async Task<IEnumerable<UserManagerVM>> GetManagersByUserIdAsync(int userId)
+        public async Task<IEnumerable<ManagerSummaryVM>> GetManagersByUserIdAsync(int userId)
         {
             var parameters = new List<DbParameter>
             {
                 new DbParameter("UserId", ParameterDirection.Input, userId)
             };
 
-            var managers = await _dbManager.ExecuteListAsync<UserManagerVM>("usp_GetManagersByUserId", parameters);
+            var managers = await _dbManager.ExecuteListAsync<ManagerSummaryVM>("usp_GetManagersByUserId", parameters);
             return managers;
         }
 

--- a/OTS.Solution/OTS.Service/UserService.cs
+++ b/OTS.Solution/OTS.Service/UserService.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
+using MobileAccounting.Entities;
 using OTS.DOMAIN.MobileAccountingVM;
 using OTS.Service.Interfaces;
 

--- a/OTS.Solution/OTS.Service/UserService.cs
+++ b/OTS.Solution/OTS.Service/UserService.cs
@@ -160,13 +160,16 @@ namespace OTS.Service
                 return BuildNotFoundResponse();
             }
 
+            var action = string.IsNullOrWhiteSpace(request.Action) ? "INSERT" : request.Action;
+
             var parameters = new List<DbParameter>
             {
                 new DbParameter("UserId", ParameterDirection.Input, request.UserId),
-                new DbParameter("ManagerIds", ParameterDirection.Input, request.ManagerIds)
+                new DbParameter("ManagerIds", ParameterDirection.Input, request.ManagerIds),
+                new DbParameter("Action", ParameterDirection.Input, action)
             };
 
-            await _dbManager.ExecuteNonQueryAsync("usp_InsertUserManagerMapping", parameters);
+            await _dbManager.ExecuteNonQueryAsync("usp_ManageUserManagerMapping", parameters);
 
             return BuildSuccessResponse("User manager mapping saved successfully.", user);
         }


### PR DESCRIPTION
## Summary
- add request/response models to support user CRUD and password workflows
- implement a user service that leverages ASP.NET Identity for create, update, change password, and reset password
- expose user management endpoints via a new UsersController and register the service in DI

## Testing
- `dotnet build` *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_690439d3cfc88330a48c3cb41d97bfd5