### PR TITLE
Add MT5 Manager integration: client, models, options, worker snapshot persistence

### DIFF
--- a/OTS.Solution/OTS.WorkflowService/IMt5ManagerClient.cs
+++ b/OTS.Solution/OTS.WorkflowService/IMt5ManagerClient.cs
@@ -1,0 +1,6 @@
+namespace OTS.WorkflowService;
+
+public interface IMt5ManagerClient
+{
+    Task<Mt5SyncSnapshot> GetOrdersAndDealsAsync(CancellationToken cancellationToken);
+}

--- a/OTS.Solution/OTS.WorkflowService/Libs/MT5ManagerAPI/README.md
+++ b/OTS.Solution/OTS.WorkflowService/Libs/MT5ManagerAPI/README.md
@@ -1,0 +1,11 @@
+# MT5 Manager SDK files
+
+`OTS.WorkflowService` references the `MetaQuotes.MT5ManagerAPI64-net2.0` NuGet package, so the normal deployment path is to restore/build the project and let NuGet copy the SDK files to the application output folder.
+
+If a deployment needs to override the NuGet-provided files, copy the official MetaTrader 5 Manager SDK runtime files into this folder and set `Mt5:SdkDirectory` to `Libs/MT5ManagerAPI`:
+
+- `MetaQuotes.MT5CommonAPI(64).dll`
+- `MetaQuotes.MT5ManagerAPI(64).dll`
+- `MT5APIManager(64).dll`
+
+The workflow service probes the application output directory first, then the optional `Mt5:SdkDirectory`, and finally the local NuGet package cache.

--- a/OTS.Solution/OTS.WorkflowService/Mt5ConnectionOptions.cs
+++ b/OTS.Solution/OTS.WorkflowService/Mt5ConnectionOptions.cs
@@ -1,0 +1,30 @@
+namespace OTS.WorkflowService;
+
+public sealed class Mt5ConnectionOptions
+{
+    public const string SectionName = "Mt5";
+
+    public string Server { get; set; } = string.Empty;
+
+    public int Port { get; set; } = 443;
+
+    public long Login { get; set; }
+
+    public string ManagerName { get; set; } = string.Empty;
+
+    public string Password { get; set; } = string.Empty;
+
+    public int PollIntervalSeconds { get; set; } = 30;
+
+    public int ConnectTimeoutSeconds { get; set; } = 10;
+
+    public string OutputDirectory { get; set; } = "mt5-data";
+
+    public string SdkDirectory { get; set; } = string.Empty;
+
+    public int HistoryLookbackDays { get; set; } = 1;
+
+    public ulong[] TradingLogins { get; set; } = Array.Empty<ulong>();
+
+    public string ServerEndpoint => $"{Server}:{Port}";
+}

--- a/OTS.Solution/OTS.WorkflowService/Mt5ManagerClient.cs
+++ b/OTS.Solution/OTS.WorkflowService/Mt5ManagerClient.cs
@@ -1,0 +1,318 @@
+using System.Collections;
+using System.Reflection;
+using Microsoft.Extensions.Options;
+
+namespace OTS.WorkflowService;
+
+public sealed class Mt5ManagerClient : IMt5ManagerClient
+{
+    private static readonly string[] ManagerApiAssemblies =
+    [
+        "MetaQuotes.MT5ManagerAPI64.dll",
+        "MetaQuotes.MT5ManagerAPI64-net2.0.dll",
+        "MetaQuotes.MT5ManagerAPI(64).dll",
+        "MetaQuotes.MT5ManagerAPI.dll"
+    ];
+
+    private readonly Mt5ConnectionOptions _options;
+    private readonly ILogger<Mt5ManagerClient> _logger;
+
+    public Mt5ManagerClient(IOptions<Mt5ConnectionOptions> options, ILogger<Mt5ManagerClient> logger)
+    {
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    public Task<Mt5SyncSnapshot> GetOrdersAndDealsAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ValidateOptions();
+
+        var assembly = LoadManagerAssembly();
+        var factoryType = assembly.GetType("MetaQuotes.MT5ManagerAPI.SMTManagerAPIFactory", throwOnError: true)!;
+        object? manager = null;
+
+        try
+        {
+            InvokeOptionalStatic(factoryType, "Initialize");
+            manager = CreateManager(factoryType);
+            Connect(manager);
+
+            var orders = ReadOrders(manager).ToArray();
+            var deals = ReadDeals(manager).ToArray();
+
+            return Task.FromResult(new Mt5SyncSnapshot(
+                DateTimeOffset.UtcNow,
+                _options.ServerEndpoint,
+                _options.Login,
+                orders,
+                deals));
+        }
+        finally
+        {
+            InvokeOptional(manager, "Disconnect");
+            InvokeOptional(manager, "Release");
+            InvokeOptionalStatic(factoryType, "Shutdown");
+        }
+    }
+
+    private void ValidateOptions()
+    {
+        if (string.IsNullOrWhiteSpace(_options.Server))
+        {
+            throw new InvalidOperationException("MT5 server is not configured.");
+        }
+
+        if (_options.Login <= 0)
+        {
+            throw new InvalidOperationException("MT5 manager login is not configured.");
+        }
+
+        if (string.IsNullOrWhiteSpace(_options.Password))
+        {
+            throw new InvalidOperationException("MT5 manager password is not configured.");
+        }
+    }
+
+    private Assembly LoadManagerAssembly()
+    {
+        var probeDirectories = BuildSdkProbeDirectories().Distinct(StringComparer.OrdinalIgnoreCase);
+        foreach (var directory in probeDirectories)
+        {
+            foreach (var fileName in ManagerApiAssemblies)
+            {
+                var assemblyPath = Path.Combine(directory, fileName);
+                if (File.Exists(assemblyPath))
+                {
+                    _logger.LogInformation("Loading MT5 Manager SDK from {AssemblyPath}.", assemblyPath);
+                    return Assembly.LoadFrom(assemblyPath);
+                }
+            }
+        }
+
+        throw new FileNotFoundException(
+            "MT5 Manager SDK was not found. Restore the MetaQuotes.MT5ManagerAPI64-net2.0 NuGet package or set Mt5:SdkDirectory to a folder that contains the official MetaQuotes MT5 Manager SDK DLLs.");
+    }
+
+    private IEnumerable<string> BuildSdkProbeDirectories()
+    {
+        yield return AppContext.BaseDirectory;
+
+        if (!string.IsNullOrWhiteSpace(_options.SdkDirectory))
+        {
+            yield return Path.GetFullPath(_options.SdkDirectory);
+        }
+
+        var packageRoot = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+            ".nuget",
+            "packages",
+            "metaquotes.mt5managerapi64-net2.0",
+            "1755.0.0");
+
+        if (Directory.Exists(packageRoot))
+        {
+            foreach (var directory in Directory.EnumerateDirectories(packageRoot, "*", SearchOption.AllDirectories))
+            {
+                yield return directory;
+            }
+        }
+    }
+
+    private static object CreateManager(Type factoryType)
+    {
+        var versionProperty = factoryType.GetProperty("ManagerAPIVersion", BindingFlags.Public | BindingFlags.Static)
+            ?? throw new MissingMethodException(factoryType.FullName, "ManagerAPIVersion");
+        var createManager = factoryType.GetMethods(BindingFlags.Public | BindingFlags.Static)
+            .FirstOrDefault(m => m.Name == "CreateManager" && m.GetParameters().Length == 2)
+            ?? throw new MissingMethodException(factoryType.FullName, "CreateManager");
+
+        var args = new[] { versionProperty.GetValue(null), null };
+        var manager = createManager.Invoke(null, args);
+        EnsureOk(args[1], "CreateManager");
+
+        return manager ?? throw new InvalidOperationException("MT5 Manager SDK returned a null manager instance.");
+    }
+
+    private void Connect(object manager)
+    {
+        var pumpMode = ResolveEnumValue(manager.GetType(), "EnPumpModes", "PUMP_MODE_FULL", "PUMP_MODE_USERS", "PUMP_MODE_NONE");
+        var timeout = (uint)TimeSpan.FromSeconds(Math.Max(1, _options.ConnectTimeoutSeconds)).TotalMilliseconds;
+        var result = InvokeRequired(manager, "Connect", _options.ServerEndpoint, (ulong)_options.Login, _options.Password, null, pumpMode, timeout);
+        EnsureOk(result, "Connect");
+    }
+
+    private IEnumerable<Mt5OrderSnapshot> ReadOrders(object manager)
+    {
+        foreach (var methodName in new[] { "OrderGetAll", "OrdersGet", "OrderRequest" })
+        {
+            var rows = InvokeOptional(manager, methodName);
+            if (rows is null || rows is bool boolResult && !boolResult)
+            {
+                continue;
+            }
+
+            foreach (var row in AsEnumerable(rows))
+            {
+                yield return new Mt5OrderSnapshot(
+                    Convert.ToInt64(ReadMember(row, "Order", "OrderTicket", "Ticket") ?? 0),
+                    Convert.ToInt64(ReadMember(row, "Login") ?? 0),
+                    Convert.ToString(ReadMember(row, "Symbol")) ?? string.Empty,
+                    Convert.ToString(ReadMember(row, "Type", "TypeName")) ?? string.Empty,
+                    Convert.ToDouble(ReadMember(row, "VolumeCurrent", "Volume", "VolumeExt") ?? 0),
+                    Convert.ToDouble(ReadMember(row, "PriceOrder", "PriceOpen", "Price") ?? 0),
+                    ConvertToDateTimeOffset(ReadMember(row, "TimeSetup", "TimeCreate", "Time")));
+            }
+
+            yield break;
+        }
+    }
+
+    private IEnumerable<Mt5DealSnapshot> ReadDeals(object manager)
+    {
+        if (_options.TradingLogins.Length == 0)
+        {
+            _logger.LogWarning("No MT5 trading logins are configured; deal history retrieval requires Mt5:TradingLogins.");
+            yield break;
+        }
+
+        var dateTo = DateTime.UtcNow;
+        var dateFrom = dateTo.AddDays(-Math.Max(1, _options.HistoryLookbackDays));
+
+        foreach (var login in _options.TradingLogins)
+        {
+            var rows = InvokeOptional(manager, "DealRequest", login, dateFrom, dateTo)
+                ?? InvokeOptional(manager, "DealsRequest", login, dateFrom, dateTo);
+            if (rows is null || rows is bool boolResult && !boolResult)
+            {
+                continue;
+            }
+
+            foreach (var row in AsEnumerable(rows))
+            {
+                yield return new Mt5DealSnapshot(
+                    Convert.ToInt64(ReadMember(row, "Deal", "DealTicket", "Ticket") ?? 0),
+                    Convert.ToInt64(ReadMember(row, "Login") ?? login),
+                    Convert.ToString(ReadMember(row, "Symbol")) ?? string.Empty,
+                    Convert.ToString(ReadMember(row, "Action", "Type", "Entry")) ?? string.Empty,
+                    Convert.ToDouble(ReadMember(row, "Volume", "VolumeExt") ?? 0),
+                    Convert.ToDouble(ReadMember(row, "Price") ?? 0),
+                    Convert.ToDouble(ReadMember(row, "Profit") ?? 0),
+                    ConvertToDateTimeOffset(ReadMember(row, "Time", "TimeMsc")));
+            }
+        }
+    }
+
+    private static IEnumerable<object> AsEnumerable(object value)
+    {
+        if (value is string)
+        {
+            yield break;
+        }
+
+        if (value is IEnumerable enumerable)
+        {
+            foreach (var item in enumerable)
+            {
+                if (item is not null)
+                {
+                    yield return item;
+                }
+            }
+        }
+        else
+        {
+            yield return value;
+        }
+    }
+
+    private static object? ReadMember(object instance, params string[] names)
+    {
+        var type = instance.GetType();
+        foreach (var name in names)
+        {
+            var property = type.GetProperty(name, BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
+            if (property is not null)
+            {
+                return property.GetValue(instance);
+            }
+
+            var method = type.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase)
+                .FirstOrDefault(m => m.Name.Equals(name, StringComparison.OrdinalIgnoreCase) && m.GetParameters().Length == 0);
+            if (method is not null)
+            {
+                return method.Invoke(instance, null);
+            }
+        }
+
+        return null;
+    }
+
+    private static DateTimeOffset ConvertToDateTimeOffset(object? value)
+    {
+        return value switch
+        {
+            DateTime dateTime => new DateTimeOffset(DateTime.SpecifyKind(dateTime, DateTimeKind.Utc)),
+            DateTimeOffset dateTimeOffset => dateTimeOffset,
+            long unixSeconds => DateTimeOffset.FromUnixTimeSeconds(unixSeconds),
+            int unixSeconds => DateTimeOffset.FromUnixTimeSeconds(unixSeconds),
+            uint unixSeconds => DateTimeOffset.FromUnixTimeSeconds(unixSeconds),
+            ulong unixSeconds => DateTimeOffset.FromUnixTimeSeconds((long)unixSeconds),
+            _ => DateTimeOffset.UtcNow
+        };
+    }
+
+    private static object? ResolveEnumValue(Type managerType, string enumName, params string[] preferredNames)
+    {
+        var enumType = managerType.GetNestedType(enumName, BindingFlags.Public)
+            ?? managerType.Assembly.GetTypes().FirstOrDefault(t => t.IsEnum && t.Name == enumName);
+        if (enumType is null)
+        {
+            return null;
+        }
+
+        foreach (var preferredName in preferredNames)
+        {
+            if (Enum.IsDefined(enumType, preferredName))
+            {
+                return Enum.Parse(enumType, preferredName);
+            }
+        }
+
+        return Enum.GetValues(enumType).GetValue(0);
+    }
+
+    private static object? InvokeOptionalStatic(Type type, string methodName)
+        => type.GetMethods(BindingFlags.Public | BindingFlags.Static)
+            .FirstOrDefault(m => m.Name == methodName && m.GetParameters().Length == 0)
+            ?.Invoke(null, null);
+
+    private static object? InvokeOptional(object? instance, string methodName, params object?[] args)
+        => instance?.GetType().GetMethods(BindingFlags.Public | BindingFlags.Instance)
+            .FirstOrDefault(m => m.Name == methodName && m.GetParameters().Length == args.Length)
+            ?.Invoke(instance, args);
+
+    private static object? InvokeRequired(object instance, string methodName, params object?[] args)
+    {
+        var method = instance.GetType().GetMethods(BindingFlags.Public | BindingFlags.Instance)
+            .FirstOrDefault(m => m.Name == methodName && m.GetParameters().Length == args.Length)
+            ?? throw new MissingMethodException(instance.GetType().FullName, methodName);
+
+        return method.Invoke(instance, args);
+    }
+
+    private static void EnsureOk(object? result, string operation)
+    {
+        if (result is null)
+        {
+            return;
+        }
+
+        if (string.Equals(result.ToString(), "MT_RET_OK", StringComparison.OrdinalIgnoreCase) || string.Equals(result.ToString(), "0", StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        throw new InvalidOperationException($"MT5 Manager SDK {operation} failed: {result}");
+    }
+}

--- a/OTS.Solution/OTS.WorkflowService/Mt5Models.cs
+++ b/OTS.Solution/OTS.WorkflowService/Mt5Models.cs
@@ -1,0 +1,29 @@
+using System.Text.Json.Serialization;
+
+namespace OTS.WorkflowService;
+
+public sealed record Mt5OrderSnapshot(
+    [property: JsonPropertyName("order")] long Order,
+    [property: JsonPropertyName("login")] long Login,
+    [property: JsonPropertyName("symbol")] string Symbol,
+    [property: JsonPropertyName("type")] string Type,
+    [property: JsonPropertyName("volume")] double Volume,
+    [property: JsonPropertyName("price")] double Price,
+    [property: JsonPropertyName("time")] DateTimeOffset Time);
+
+public sealed record Mt5DealSnapshot(
+    [property: JsonPropertyName("deal")] long Deal,
+    [property: JsonPropertyName("login")] long Login,
+    [property: JsonPropertyName("symbol")] string Symbol,
+    [property: JsonPropertyName("action")] string Action,
+    [property: JsonPropertyName("volume")] double Volume,
+    [property: JsonPropertyName("price")] double Price,
+    [property: JsonPropertyName("profit")] double Profit,
+    [property: JsonPropertyName("time")] DateTimeOffset Time);
+
+public sealed record Mt5SyncSnapshot(
+    DateTimeOffset SyncedAt,
+    string Server,
+    long ManagerLogin,
+    IReadOnlyCollection<Mt5OrderSnapshot> Orders,
+    IReadOnlyCollection<Mt5DealSnapshot> Deals);

--- a/OTS.Solution/OTS.WorkflowService/OTS.WorkflowService.csproj
+++ b/OTS.Solution/OTS.WorkflowService/OTS.WorkflowService.csproj
@@ -9,5 +9,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
+    <PackageReference Include="MetaQuotes.MT5ManagerAPI64-net2.0" Version="1755.0.0" />
   </ItemGroup>
 </Project>

--- a/OTS.Solution/OTS.WorkflowService/Program.cs
+++ b/OTS.Solution/OTS.WorkflowService/Program.cs
@@ -1,6 +1,9 @@
 using OTS.WorkflowService;
 
 var builder = Host.CreateApplicationBuilder(args);
+
+builder.Services.Configure<Mt5ConnectionOptions>(builder.Configuration.GetSection(Mt5ConnectionOptions.SectionName));
+builder.Services.AddSingleton<IMt5ManagerClient, Mt5ManagerClient>();
 builder.Services.AddHostedService<Worker>();
 
 var host = builder.Build();

--- a/OTS.Solution/OTS.WorkflowService/Worker.cs
+++ b/OTS.Solution/OTS.WorkflowService/Worker.cs
@@ -1,24 +1,63 @@
+using System.Text.Json;
+using Microsoft.Extensions.Options;
+
 namespace OTS.WorkflowService
 {
     public class Worker : BackgroundService
     {
-        private readonly ILogger<Worker> _logger;
+        private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+        {
+            WriteIndented = true
+        };
 
-        public Worker(ILogger<Worker> logger)
+        private readonly ILogger<Worker> _logger;
+        private readonly IMt5ManagerClient _mt5ManagerClient;
+        private readonly Mt5ConnectionOptions _options;
+
+        public Worker(
+            ILogger<Worker> logger,
+            IMt5ManagerClient mt5ManagerClient,
+            IOptions<Mt5ConnectionOptions> options)
         {
             _logger = logger;
+            _mt5ManagerClient = mt5ManagerClient;
+            _options = options.Value;
         }
 
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         {
             while (!stoppingToken.IsCancellationRequested)
             {
-                if (_logger.IsEnabled(LogLevel.Information))
+                try
                 {
-                    _logger.LogInformation("Worker running at: {time}", DateTimeOffset.Now);
+                    var snapshot = await _mt5ManagerClient.GetOrdersAndDealsAsync(stoppingToken).ConfigureAwait(false);
+                    await SaveSnapshotAsync(snapshot, stoppingToken).ConfigureAwait(false);
+
+                    _logger.LogInformation(
+                        "MT5 sync completed at {SyncedAt}. Orders: {OrderCount}; Deals: {DealCount}.",
+                        snapshot.SyncedAt,
+                        snapshot.Orders.Count,
+                        snapshot.Deals.Count);
                 }
-                await Task.Delay(1000, stoppingToken);
+                catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+                {
+                    break;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "MT5 sync failed for server {Server}:{Port}.", _options.Server, _options.Port);
+                }
+
+                await Task.Delay(TimeSpan.FromSeconds(Math.Max(1, _options.PollIntervalSeconds)), stoppingToken).ConfigureAwait(false);
             }
+        }
+
+        private async Task SaveSnapshotAsync(Mt5SyncSnapshot snapshot, CancellationToken cancellationToken)
+        {
+            Directory.CreateDirectory(_options.OutputDirectory);
+            var fileName = $"mt5-orders-deals-{snapshot.SyncedAt:yyyyMMddHHmmss}.json";
+            var filePath = Path.Combine(_options.OutputDirectory, fileName);
+            await File.WriteAllTextAsync(filePath, JsonSerializer.Serialize(snapshot, JsonOptions), cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/OTS.Solution/OTS.WorkflowService/appsettings.json
+++ b/OTS.Solution/OTS.WorkflowService/appsettings.json
@@ -4,5 +4,18 @@
       "Default": "Information",
       "Microsoft.Hosting.Lifetime": "Information"
     }
+  },
+  "Mt5": {
+    "Server": "85.195.95.30",
+    "Port": 443,
+    "Login": 49630,
+    "ManagerName": "CT VIEW MANAGER",
+    "Password": "Hoc@12345",
+    "PollIntervalSeconds": 30,
+    "ConnectTimeoutSeconds": 10,
+    "OutputDirectory": "mt5-data",
+    "SdkDirectory": "",
+    "HistoryLookbackDays": 1,
+    "TradingLogins": []
   }
 }


### PR DESCRIPTION
### Motivation

- Add support for synchronizing orders and deals from a MetaTrader 5 manager using the official MT5 Manager SDK and persist snapshots for later inspection.
- Provide configurable connection options and a pluggable manager client to isolate SDK usage and probing logic.

### Description

- Introduce `IMt5ManagerClient`, `Mt5ManagerClient`, and model records `Mt5OrderSnapshot`, `Mt5DealSnapshot`, and `Mt5SyncSnapshot` to encapsulate MT5 data retrieval and representation.
- Add `Mt5ConnectionOptions` with the `Mt5` configuration section and wire it into DI via `Program.cs` using `builder.Services.Configure<Mt5ConnectionOptions>` and register `Mt5ManagerClient` as a singleton for `IMt5ManagerClient`.
- Implement SDK probing and dynamic invocation logic in `Mt5ManagerClient` to locate the MetaQuotes SDK DLLs from application output, an optional `Mt5:SdkDirectory`, or the local NuGet package cache, and call manager APIs to read orders and deals while handling multiple API variants.
- Update `Worker` to call `IMt5ManagerClient.GetOrdersAndDealsAsync`, log results, and save JSON snapshots to the configured `OutputDirectory`, and add `MetaQuotes.MT5ManagerAPI64-net2.0` package reference and an SDK `README.md` describing deployment overrides and required runtime files.

### Testing

- No automated tests were added or executed as part of this change.
- Manual runtime behavior is exercised by the updated `Worker` flow which writes JSON snapshots to the configured `Mt5:OutputDirectory` when a manager connection is available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a42a4d4cfc083308cbf9f08c540b7d2)