### PR TITLE
Add MT5 trade sync utility worker

### DIFF
--- a/OTS.Solution/OTS.Solution.sln
+++ b/OTS.Solution/OTS.Solution.sln
@@ -13,6 +13,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OTS.MobileAccountingAPI", "
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OTS.Service", "OTS.Service\OTS.Service.csproj", "{F0AC165F-D05F-4F29-9EED-C214261EC1B6}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OTS.UtilityService", "OTS.UtilityService\OTS.UtilityService.csproj", "{2F781452-69C1-4D59-B0A8-5F45B7803B1B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -35,6 +37,10 @@ Global
 		{F0AC165F-D05F-4F29-9EED-C214261EC1B6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F0AC165F-D05F-4F29-9EED-C214261EC1B6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F0AC165F-D05F-4F29-9EED-C214261EC1B6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2F781452-69C1-4D59-B0A8-5F45B7803B1B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2F781452-69C1-4D59-B0A8-5F45B7803B1B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2F781452-69C1-4D59-B0A8-5F45B7803B1B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2F781452-69C1-4D59-B0A8-5F45B7803B1B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -43,6 +49,7 @@ Global
 		{B9AD0083-8C73-4AC2-BC28-E360E0BE542F} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 		{C60143A0-E461-43B7-A917-9910B1D41A5C} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 		{F0AC165F-D05F-4F29-9EED-C214261EC1B6} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{2F781452-69C1-4D59-B0A8-5F45B7803B1B} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {9DB53BEE-B5DD-41EB-82D0-8DF0273A39E6}

--- a/OTS.Solution/OTS.UtilityService/Models/Mt5Trade.cs
+++ b/OTS.Solution/OTS.UtilityService/Models/Mt5Trade.cs
@@ -1,0 +1,10 @@
+namespace OTS.UtilityService.Models;
+
+public sealed record Mt5Trade(
+    ulong DealId,
+    ulong Login,
+    string Symbol,
+    decimal Volume,
+    decimal Price,
+    DateTimeOffset Time,
+    string Side);

--- a/OTS.Solution/OTS.UtilityService/OTS.UtilityService.csproj
+++ b/OTS.Solution/OTS.UtilityService/OTS.UtilityService.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk.Worker">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <UserSecretsId>dotnet-OTS.UtilityService-mt5-tradesync</UserSecretsId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/OTS.Solution/OTS.UtilityService/Options/Mt5ManagerOptions.cs
+++ b/OTS.Solution/OTS.UtilityService/Options/Mt5ManagerOptions.cs
@@ -1,0 +1,29 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace OTS.UtilityService.Options;
+
+public sealed class Mt5ManagerOptions
+{
+    public const string SectionName = "Mt5Manager";
+
+    [Required]
+    public string Server { get; init; } = string.Empty;
+
+    [Range(1, 65535)]
+    public int Port { get; init; } = 443;
+
+    [Required]
+    public string ManagerName { get; init; } = string.Empty;
+
+    [Range(1, long.MaxValue)]
+    public long Login { get; init; }
+
+    [Required]
+    public string Password { get; init; } = string.Empty;
+
+    [Range(1, int.MaxValue)]
+    public int PollIntervalSeconds { get; init; } = 30;
+
+    [Range(1, int.MaxValue)]
+    public int ConnectionTimeoutSeconds { get; init; } = 15;
+}

--- a/OTS.Solution/OTS.UtilityService/Program.cs
+++ b/OTS.Solution/OTS.UtilityService/Program.cs
@@ -1,0 +1,17 @@
+using OTS.UtilityService.Options;
+using OTS.UtilityService.Services;
+
+var builder = Host.CreateApplicationBuilder(args);
+
+builder.Services
+    .AddOptions<Mt5ManagerOptions>()
+    .Bind(builder.Configuration.GetSection(Mt5ManagerOptions.SectionName))
+    .ValidateDataAnnotations()
+    .Validate(options => options.Port > 0 && options.Port <= 65535, "MT5 manager port must be between 1 and 65535.")
+    .ValidateOnStart();
+
+builder.Services.AddSingleton<IMt5ManagerClient, Mt5ManagerClient>();
+builder.Services.AddHostedService<Mt5TradeSyncWorker>();
+
+var host = builder.Build();
+host.Run();

--- a/OTS.Solution/OTS.UtilityService/Properties/launchSettings.json
+++ b/OTS.Solution/OTS.UtilityService/Properties/launchSettings.json
@@ -1,0 +1,11 @@
+{
+  "profiles": {
+    "OTS.UtilityService": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "environmentVariables": {
+        "DOTNET_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/OTS.Solution/OTS.UtilityService/Services/IMt5ManagerClient.cs
+++ b/OTS.Solution/OTS.UtilityService/Services/IMt5ManagerClient.cs
@@ -1,0 +1,8 @@
+using OTS.UtilityService.Models;
+
+namespace OTS.UtilityService.Services;
+
+public interface IMt5ManagerClient
+{
+    Task<IReadOnlyCollection<Mt5Trade>> GetTradesAsync(DateTimeOffset from, CancellationToken cancellationToken);
+}

--- a/OTS.Solution/OTS.UtilityService/Services/Mt5ManagerClient.cs
+++ b/OTS.Solution/OTS.UtilityService/Services/Mt5ManagerClient.cs
@@ -1,0 +1,44 @@
+using System.Net.Sockets;
+using Microsoft.Extensions.Options;
+using OTS.UtilityService.Models;
+using OTS.UtilityService.Options;
+
+namespace OTS.UtilityService.Services;
+
+public sealed class Mt5ManagerClient : IMt5ManagerClient
+{
+    private readonly Mt5ManagerOptions _options;
+    private readonly ILogger<Mt5ManagerClient> _logger;
+
+    public Mt5ManagerClient(IOptions<Mt5ManagerOptions> options, ILogger<Mt5ManagerClient> logger)
+    {
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    public async Task<IReadOnlyCollection<Mt5Trade>> GetTradesAsync(DateTimeOffset from, CancellationToken cancellationToken)
+    {
+        await VerifyServerReachableAsync(cancellationToken);
+
+        // TODO: Replace this connectivity check with the official MetaTrader 5 Manager API adapter.
+        // The native MT5 Manager API is distributed by MetaQuotes/brokers and is not included in this repository.
+        // Keep the adapter behind IMt5ManagerClient so the worker does not change when the API DLL/package is added.
+        _logger.LogInformation(
+            "MT5 manager endpoint {Server}:{Port} is reachable for manager {ManagerName} ({Login}); trade fetch adapter is pending.",
+            _options.Server,
+            _options.Port,
+            _options.ManagerName,
+            _options.Login);
+
+        return Array.Empty<Mt5Trade>();
+    }
+
+    private async Task VerifyServerReachableAsync(CancellationToken cancellationToken)
+    {
+        using var client = new TcpClient();
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(_options.ConnectionTimeoutSeconds));
+        using var linkedToken = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeout.Token);
+
+        await client.ConnectAsync(_options.Server, _options.Port, linkedToken.Token);
+    }
+}

--- a/OTS.Solution/OTS.UtilityService/Services/Mt5TradeSyncWorker.cs
+++ b/OTS.Solution/OTS.UtilityService/Services/Mt5TradeSyncWorker.cs
@@ -1,0 +1,69 @@
+using Microsoft.Extensions.Options;
+using OTS.UtilityService.Options;
+
+namespace OTS.UtilityService.Services;
+
+public sealed class Mt5TradeSyncWorker : BackgroundService
+{
+    private readonly IMt5ManagerClient _managerClient;
+    private readonly Mt5ManagerOptions _options;
+    private readonly ILogger<Mt5TradeSyncWorker> _logger;
+
+    public Mt5TradeSyncWorker(
+        IMt5ManagerClient managerClient,
+        IOptions<Mt5ManagerOptions> options,
+        ILogger<Mt5TradeSyncWorker> logger)
+    {
+        _managerClient = managerClient;
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var lastSyncTime = DateTimeOffset.UtcNow.AddMinutes(-5);
+        var pollInterval = TimeSpan.FromSeconds(_options.PollIntervalSeconds);
+
+        _logger.LogInformation(
+            "MT5 trade sync worker started for {Server}:{Port} manager {ManagerName} ({Login}).",
+            _options.Server,
+            _options.Port,
+            _options.ManagerName,
+            _options.Login);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                var trades = await _managerClient.GetTradesAsync(lastSyncTime, stoppingToken);
+                foreach (var trade in trades.OrderBy(trade => trade.Time))
+                {
+                    _logger.LogInformation(
+                        "MT5 trade received: DealId={DealId}, Login={Login}, Symbol={Symbol}, Volume={Volume}, Price={Price}, Side={Side}, Time={Time:o}",
+                        trade.DealId,
+                        trade.Login,
+                        trade.Symbol,
+                        trade.Volume,
+                        trade.Price,
+                        trade.Side,
+                        trade.Time);
+
+                    if (trade.Time > lastSyncTime)
+                    {
+                        lastSyncTime = trade.Time;
+                    }
+                }
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "MT5 trade sync failed. The worker will retry in {PollIntervalSeconds} seconds.", _options.PollIntervalSeconds);
+            }
+
+            await Task.Delay(pollInterval, stoppingToken);
+        }
+    }
+}

--- a/OTS.Solution/OTS.UtilityService/appsettings.Development.json
+++ b/OTS.Solution/OTS.UtilityService/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  }
+}

--- a/OTS.Solution/OTS.UtilityService/appsettings.json
+++ b/OTS.Solution/OTS.UtilityService/appsettings.json
@@ -1,0 +1,17 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "Mt5Manager": {
+    "Server": "85.195.95.30",
+    "Port": 443,
+    "ManagerName": "CT VIEW MANAGER",
+    "Login": 49630,
+    "Password": "Rto@12345",
+    "PollIntervalSeconds": 30,
+    "ConnectionTimeoutSeconds": 15
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a dedicated background worker to poll MT5 manager for trades and centralize MT5 connectivity/configuration in a separate utility project.
- Keep the MT5 Manager API integration behind an adapter interface so the official manager API can be added later without changing the worker code.

### Description
- Add a new `OTS.UtilityService` .NET 8 worker project to the solution and include it in the solution file for the repository.
- Introduce `Mt5ManagerOptions` with validation for server, port, manager name, login, password, poll interval, and connection timeout, and bind the section in `Program.cs`.
- Add `IMt5ManagerClient` interface and a `Mt5ManagerClient` placeholder that verifies TCP connectivity to the configured MT5 manager endpoint and logs reachability; this keeps an adapter boundary for the real MT5 Manager API.
- Add `Mt5Trade` record and `Mt5TradeSyncWorker` hosted service that polls `GetTradesAsync`, logs incoming trades ordered by time, advances `lastSyncTime`, and retries on failures.

### Testing
- `git diff --check` was run and reported no trailing whitespace or index problems.
- Attempting `dotnet build OTS.Solution/OTS.Solution.sln` could not be executed in this environment because the `dotnet` CLI is not installed, so the project build was not verified here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a42b13f0cc083308233ca661931da21)