### PR TITLE
Add MT5 manager trade and order polling

### DIFF
--- a/OTS.Solution/OTS.WorkflowService/Mt5ManagerClient.cs
+++ b/OTS.Solution/OTS.WorkflowService/Mt5ManagerClient.cs
@@ -108,6 +108,11 @@ public sealed class Mt5ManagerClient : IDisposable
 
     public Mt5Snapshot GetTradeAndOrderSnapshot()
     {
+        if (TryGetSnapshotFromMetaTrader5NetApi(out var terminalSnapshot))
+        {
+            return terminalSnapshot;
+        }
+
         Connect();
         ArgumentNullException.ThrowIfNull(_manager);
 
@@ -128,6 +133,119 @@ public sealed class Mt5ManagerClient : IDisposable
 
         _connected = false;
         SMTManagerAPIFactory.Shutdown();
+    }
+
+
+    private bool TryGetSnapshotFromMetaTrader5NetApi(out Mt5Snapshot snapshot)
+    {
+        snapshot = new Mt5Snapshot(Array.Empty<string>(), Array.Empty<string>());
+
+        var assembly = AppDomain.CurrentDomain.GetAssemblies()
+            .FirstOrDefault(a => a.GetName().Name?.Contains("MetaTrader5", StringComparison.OrdinalIgnoreCase) == true)
+            ?? TryLoadAssembly("MetaTrader5.Net.API")
+            ?? TryLoadAssembly("MetaTrader5.Net");
+
+        if (assembly is null)
+        {
+            return false;
+        }
+
+        foreach (var apiType in assembly.GetTypes().Where(t => !t.IsAbstract && !t.IsInterface && t.GetConstructor(Type.EmptyTypes) is not null))
+        {
+            var api = Activator.CreateInstance(apiType);
+            if (api is null)
+            {
+                continue;
+            }
+
+            if (!TryConnectMetaTrader5NetApi(api))
+            {
+                continue;
+            }
+
+            var from = DateTime.UtcNow.AddDays(-Math.Max(1, _options.DealHistoryDays));
+            var to = DateTime.UtcNow;
+            var orders = InvokeFirstDataMethod(api, new[] { "OrdersGet", "Orders", "GetOrders", "PositionsGet", "Positions", "GetPositions" }, Array.Empty<object?>(), new object?[] { _options.OrderGroupMask });
+            var deals = InvokeFirstDataMethod(api, new[] { "HistoryDealsGet", "DealsGet", "GetDeals", "HistoryOrdersGet", "GetHistoryOrders" }, new object?[] { from, to }, new object?[] { from, to, _options.OrderGroupMask });
+
+            snapshot = new Mt5Snapshot(NormalizeRows(orders).Take((int)_options.MaxRows).ToList(), NormalizeRows(deals).Take((int)_options.MaxRows).ToList());
+            return true;
+        }
+
+        return false;
+    }
+
+    private bool TryConnectMetaTrader5NetApi(object api)
+    {
+        var login = Convert.ToInt64(_options.Login);
+        return IsSuccess(InvokeFirstDataMethod(api, new[] { "Initialize", "Init", "Connect", "Login" },
+                new object?[] { _options.Server, login, _options.Password },
+                new object?[] { login, _options.Password, _options.Server },
+                new object?[] { _options.Server, _options.Login, _options.Password },
+                Array.Empty<object?>()))
+            || IsSuccess(InvokeFirstDataMethod(api, new[] { "Login", "Connect" },
+                new object?[] { login, _options.Password, _options.Server },
+                new object?[] { _options.Server, login, _options.Password }));
+    }
+
+    private static Assembly? TryLoadAssembly(string name)
+    {
+        try
+        {
+            return Assembly.Load(name);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static object? InvokeFirstDataMethod(object target, IEnumerable<string> methodNames, params object?[][] argumentSets)
+    {
+        foreach (var methodName in methodNames)
+        {
+            foreach (var arguments in argumentSets)
+            {
+                var method = target.GetType().GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static)
+                    .FirstOrDefault(candidate => string.Equals(candidate.Name, methodName, StringComparison.OrdinalIgnoreCase)
+                        && ParametersMatch(candidate.GetParameters(), arguments));
+                if (method is null)
+                {
+                    continue;
+                }
+
+                try
+                {
+                    return method.Invoke(target, ConvertArguments(method.GetParameters(), arguments!));
+                }
+                catch
+                {
+                    // Try next overload/name.
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static bool IsSuccess(object? result)
+    {
+        return result is null || result is true || (result is not bool && result is IConvertible convertible && convertible.ToInt64(System.Globalization.CultureInfo.InvariantCulture) == 0);
+    }
+
+    private static IEnumerable<string> NormalizeRows(object? value)
+    {
+        if (value is null)
+        {
+            return Array.Empty<string>();
+        }
+
+        if (value is System.Collections.IEnumerable enumerable && value is not string)
+        {
+            return enumerable.Cast<object?>().Where(item => item is not null).Select(item => SerializeObject(item!));
+        }
+
+        return new[] { SerializeObject(value) };
     }
 
     private IEnumerable<string> ReadOrders(CIMTManagerAPI manager)
@@ -214,7 +332,7 @@ public sealed class Mt5ManagerClient : IDisposable
         throw new InvalidOperationException($"None of the MT5 Manager API methods were found: {string.Join(", ", methodNames)}.");
     }
 
-    private static bool ParametersMatch(ParameterInfo[] parameters, object[] arguments)
+    private static bool ParametersMatch(ParameterInfo[] parameters, object?[] arguments)
     {
         if (parameters.Length != arguments.Length)
         {
@@ -238,7 +356,7 @@ public sealed class Mt5ManagerClient : IDisposable
         return true;
     }
 
-    private static object?[] ConvertArguments(ParameterInfo[] parameters, object[] arguments)
+    private static object?[] ConvertArguments(ParameterInfo[] parameters, object?[] arguments)
     {
         var converted = new object?[arguments.Length];
         for (var i = 0; i < arguments.Length; i++)

--- a/OTS.Solution/OTS.WorkflowService/Mt5ManagerClient.cs
+++ b/OTS.Solution/OTS.WorkflowService/Mt5ManagerClient.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using System.Runtime.Loader;
 using System.Text.Json;
 
 namespace OTS.WorkflowService;
@@ -206,9 +207,57 @@ public sealed class Mt5ManagerClient : IDisposable
 
     private static Assembly LoadManagerAssembly()
     {
-        return AppDomain.CurrentDomain.GetAssemblies()
-                   .FirstOrDefault(a => a.GetName().Name?.Contains("MT5ManagerAPI", StringComparison.OrdinalIgnoreCase) == true)
-               ?? Assembly.Load("MetaQuotes.MT5ManagerAPI64-net2.0");
+        var loadedAssembly = AppDomain.CurrentDomain.GetAssemblies()
+            .FirstOrDefault(a => a.GetName().Name?.Contains("MT5ManagerAPI", StringComparison.OrdinalIgnoreCase) == true);
+        if (loadedAssembly is not null)
+        {
+            return loadedAssembly;
+        }
+
+        foreach (var assemblyPath in GetManagerAssemblyCandidates())
+        {
+            try
+            {
+                return AssemblyLoadContext.Default.LoadFromAssemblyPath(assemblyPath);
+            }
+            catch (FileLoadException)
+            {
+                return Assembly.LoadFrom(assemblyPath);
+            }
+            catch (BadImageFormatException)
+            {
+                // Ignore native helper DLLs; continue until the managed wrapper DLL is found.
+            }
+        }
+
+        throw new FileNotFoundException(
+            "Unable to locate the managed MT5 Manager API assembly. Ensure the MetaQuotes.MT5ManagerAPI64-net2.0 package DLLs are copied to the WorkflowService output folder.");
+    }
+
+    private static IEnumerable<string> GetManagerAssemblyCandidates()
+    {
+        var baseDirectory = AppContext.BaseDirectory;
+        var candidateNames = new[]
+        {
+            "MetaQuotes.MT5ManagerAPI64.dll",
+            "MetaQuotes.MT5ManagerAPI.dll",
+            "MT5ManagerAPI64.dll",
+            "MT5ManagerAPI.dll"
+        };
+
+        foreach (var candidateName in candidateNames)
+        {
+            var path = Path.Combine(baseDirectory, candidateName);
+            if (File.Exists(path))
+            {
+                yield return path;
+            }
+        }
+
+        foreach (var path in Directory.EnumerateFiles(baseDirectory, "*MT5*Manager*API*.dll", SearchOption.AllDirectories))
+        {
+            yield return path;
+        }
     }
 
     private static Type GetFactoryType(Assembly assembly)

--- a/OTS.Solution/OTS.WorkflowService/Mt5ManagerClient.cs
+++ b/OTS.Solution/OTS.WorkflowService/Mt5ManagerClient.cs
@@ -1,0 +1,179 @@
+using System.Reflection;
+using System.Text.Json;
+
+namespace OTS.WorkflowService;
+
+public sealed class Mt5ManagerClient : IDisposable
+{
+    private readonly Mt5ManagerOptions _options;
+    private readonly ILogger<Mt5ManagerClient> _logger;
+    private object? _manager;
+    private bool _connected;
+
+    public Mt5ManagerClient(Mt5ManagerOptions options, ILogger<Mt5ManagerClient> logger)
+    {
+        _options = options;
+        _logger = logger;
+    }
+
+    public void Connect()
+    {
+        if (_connected)
+        {
+            return;
+        }
+
+        var assembly = LoadManagerAssembly();
+        InitializeFactory(assembly);
+        _manager = CreateManager(assembly);
+        InvokeByName(_manager, "Connect", _options.Server, _options.Login, _options.Password, null, _options.PumpingMode, _options.TimeoutMilliseconds);
+        _connected = true;
+        _logger.LogInformation("Connected to MT5 Manager server {Server} as login {Login}.", _options.Server, _options.Login);
+    }
+
+    public Mt5Snapshot GetTradeAndOrderSnapshot()
+    {
+        Connect();
+        ArgumentNullException.ThrowIfNull(_manager);
+
+        var orders = InvokeFirstAvailable(_manager,
+            new[] { "OrderGet", "OrdersGet", "OrderGetAll", "OrderGetPage", "OrdersGetPage" },
+            new object?[][]
+            {
+                Array.Empty<object?>(),
+                new object?[] { _options.PreviewCount },
+                new object?[] { 0u, _options.PreviewCount },
+                new object?[] { 0UL, _options.PreviewCount }
+            });
+
+        var trades = InvokeFirstAvailable(_manager,
+            new[] { "DealGet", "DealsGet", "DealGetAll", "TradeGet", "TradesGet", "PositionGet", "PositionsGet" },
+            new object?[][]
+            {
+                Array.Empty<object?>(),
+                new object?[] { _options.PreviewCount },
+                new object?[] { 0u, _options.PreviewCount },
+                new object?[] { 0UL, _options.PreviewCount }
+            });
+
+        return new Mt5Snapshot(Normalize(orders), Normalize(trades));
+    }
+
+    public void Dispose()
+    {
+        if (_manager is null)
+        {
+            return;
+        }
+
+        InvokeOptional(_manager, "Disconnect");
+        (_manager as IDisposable)?.Dispose();
+        _connected = false;
+    }
+
+    private static Assembly LoadManagerAssembly()
+    {
+        return AppDomain.CurrentDomain.GetAssemblies()
+                   .FirstOrDefault(a => a.GetName().Name?.Contains("MT5ManagerAPI", StringComparison.OrdinalIgnoreCase) == true)
+               ?? Assembly.Load("MetaQuotes.MT5ManagerAPI64-net2.0");
+    }
+
+    private static void InitializeFactory(Assembly assembly)
+    {
+        var factory = assembly.GetTypes().FirstOrDefault(t => t.Name.Contains("Factory", StringComparison.OrdinalIgnoreCase));
+        if (factory is null)
+        {
+            return;
+        }
+
+        InvokeOptional(factory, "Initialize");
+        InvokeOptional(factory, "Init");
+    }
+
+    private static object CreateManager(Assembly assembly)
+    {
+        var factory = assembly.GetTypes().FirstOrDefault(t => t.Name.Contains("Factory", StringComparison.OrdinalIgnoreCase));
+        if (factory is not null)
+        {
+            foreach (var methodName in new[] { "CreateManager", "Create", "ManagerCreate" })
+            {
+                var manager = InvokeOptional(factory, methodName);
+                if (manager is not null)
+                {
+                    return manager;
+                }
+            }
+        }
+
+        var managerType = assembly.GetTypes().FirstOrDefault(t => t.Name.Contains("Manager", StringComparison.OrdinalIgnoreCase) && !t.IsInterface && t.GetConstructor(Type.EmptyTypes) is not null)
+            ?? throw new InvalidOperationException("Unable to find an MT5 manager type in the MetaQuotes assembly.");
+
+        return Activator.CreateInstance(managerType)!;
+    }
+
+    private static object? InvokeFirstAvailable(object target, IEnumerable<string> methodNames, IEnumerable<object?[]> argumentSets)
+    {
+        foreach (var methodName in methodNames)
+        {
+            foreach (var arguments in argumentSets)
+            {
+                var value = InvokeOptional(target, methodName, arguments);
+                if (value is not null)
+                {
+                    return value;
+                }
+            }
+        }
+
+        throw new MissingMethodException("No compatible MT5 manager method was found for reading orders/trades.");
+    }
+
+    private static object? InvokeOptional(object target, string methodName, params object?[] arguments)
+    {
+        try
+        {
+            return InvokeByName(target, methodName, arguments);
+        }
+        catch (MissingMethodException)
+        {
+            return null;
+        }
+    }
+
+    private static object? InvokeByName(object target, string methodName, params object?[] arguments)
+    {
+        var type = target as Type ?? target.GetType();
+        var flags = BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static;
+        var method = type.GetMethods(flags)
+            .FirstOrDefault(m => string.Equals(m.Name, methodName, StringComparison.OrdinalIgnoreCase) && m.GetParameters().Length == arguments.Length);
+
+        if (method is null)
+        {
+            throw new MissingMethodException(type.FullName, methodName);
+        }
+
+        return method.Invoke(target is Type ? null : target, arguments);
+    }
+
+    private static IReadOnlyList<string> Normalize(object? value)
+    {
+        if (value is null)
+        {
+            return Array.Empty<string>();
+        }
+
+        if (value is System.Collections.IEnumerable enumerable && value is not string)
+        {
+            return enumerable.Cast<object?>().Select(Serialize).ToList();
+        }
+
+        return new[] { Serialize(value) };
+    }
+
+    private static string Serialize(object? value)
+    {
+        return JsonSerializer.Serialize(value, value?.GetType() ?? typeof(object), new JsonSerializerOptions { WriteIndented = false });
+    }
+}
+
+public sealed record Mt5Snapshot(IReadOnlyList<string> Orders, IReadOnlyList<string> Trades);

--- a/OTS.Solution/OTS.WorkflowService/Mt5ManagerClient.cs
+++ b/OTS.Solution/OTS.WorkflowService/Mt5ManagerClient.cs
@@ -40,7 +40,7 @@ public sealed class Mt5ManagerClient : IDisposable
         _factory = Activator.CreateInstance(factoryType) ?? factoryType;
 
         InitializeFactory(_factory);
-        var version = ReadApiVersion(_factory);
+        var version = ReadApiVersionConstant(_factory) ?? 0;
         _manager = CreateManager(_factory, version);
 
         var connectResult = Invoke(
@@ -216,20 +216,6 @@ public sealed class Mt5ManagerClient : IDisposable
         // initialization is not required. Continue to Version/CreateManager/Connect,
         // because those calls are the real validation for getting orders and deals
         // with manager credentials.
-    }
-
-    private static uint ReadApiVersion(object factory)
-    {
-        try
-        {
-            var invocation = InvokeWithOut(factory, "Version", typeof(uint));
-            EnsureOk(invocation.ReturnValue, "Version");
-            return invocation.OutValues.OfType<uint>().FirstOrDefault();
-        }
-        catch (MissingMethodException)
-        {
-            return ReadApiVersionConstant(factory) ?? 0;
-        }
     }
 
     private static object CreateManager(object factory, uint version)

--- a/OTS.Solution/OTS.WorkflowService/Mt5ManagerClient.cs
+++ b/OTS.Solution/OTS.WorkflowService/Mt5ManagerClient.cs
@@ -194,16 +194,20 @@ public sealed class Mt5ManagerClient : IDisposable
     private static void InitializeFactory(object factory)
     {
         var nativeDllPath = GetNativeManagerDllPath();
-        object? result;
-        try
+        object? result = InvokeIfExists(factory, "Initialize", nativeDllPath ?? AppContext.BaseDirectory)
+            ?? InvokeIfExists(factory, "Initialize", (string?)null)
+            ?? InvokeIfExists(factory, "Initialize")
+            ?? InvokeIfExists(factory, "Init", nativeDllPath ?? AppContext.BaseDirectory)
+            ?? InvokeIfExists(factory, "Init", (string?)null)
+            ?? InvokeIfExists(factory, "Init");
+
+        if (result is null)
         {
-            result = nativeDllPath is null
-                ? Invoke(factory, "Initialize", (string?)null)
-                : Invoke(factory, "Initialize", nativeDllPath);
-        }
-        catch (MissingMethodException)
-        {
-            result = Invoke(factory, "Initialize");
+            // Some NuGet wrappers pre-load the native Manager API from the package output
+            // and expose only CreateManager/Version. Do not fail the workflow here; the
+            // following Version/CreateManager/Connect calls will validate whether the
+            // package can actually create a manager session.
+            return;
         }
 
         EnsureOk(result, "Initialize");
@@ -310,7 +314,16 @@ public sealed class Mt5ManagerClient : IDisposable
 
     private static Type? GetFactoryTypeOrDefault(Assembly assembly)
     {
-        return assembly.GetTypes().FirstOrDefault(t => string.Equals(t.Name, "CMTManagerAPIFactory", StringComparison.OrdinalIgnoreCase));
+        var types = assembly.GetTypes();
+        return types.FirstOrDefault(t => string.Equals(t.Name, "CMTManagerAPIFactory", StringComparison.OrdinalIgnoreCase) && HasMethod(t, "CreateManager"))
+            ?? types.FirstOrDefault(t => t.Name.Contains("ManagerAPIFactory", StringComparison.OrdinalIgnoreCase) && HasMethod(t, "CreateManager"))
+            ?? types.FirstOrDefault(t => t.Name.Contains("ManagerFactory", StringComparison.OrdinalIgnoreCase) && HasMethod(t, "CreateManager"));
+    }
+
+    private static bool HasMethod(Type type, string methodName)
+    {
+        return type.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static)
+            .Any(m => string.Equals(m.Name, methodName, StringComparison.OrdinalIgnoreCase));
     }
 
     private static object? InvokeIfExists(object target, string methodName, params object?[] arguments)

--- a/OTS.Solution/OTS.WorkflowService/Mt5ManagerClient.cs
+++ b/OTS.Solution/OTS.WorkflowService/Mt5ManagerClient.cs
@@ -1,18 +1,14 @@
 using System.Reflection;
 using System.Text.Json;
-using MetaQuotes.MT5CommonAPI;
-using MetaQuotes.MT5ManagerAPI;
 
 namespace OTS.WorkflowService;
 
-public sealed class Mt5ManagerClient : IDisposable
+public sealed class Mt5ManagerClient
 {
     private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = false };
 
     private readonly Mt5ManagerOptions _options;
     private readonly ILogger<Mt5ManagerClient> _logger;
-    private CIMTManagerAPI? _manager;
-    private bool _connected;
 
     public Mt5ManagerClient(Mt5ManagerOptions options, ILogger<Mt5ManagerClient> logger)
     {
@@ -20,126 +16,8 @@ public sealed class Mt5ManagerClient : IDisposable
         _logger = logger;
     }
 
-    public void Connect()
-    {
-        if (_connected)
-        {
-            return;
-        }
-
-        var result = InitializeManagerApi(_options.NativeLibraryPath);
-        ThrowIfFailed(result, "Initialize MT5 Manager API. If this fails, set Mt5Manager:NativeLibraryPath to the folder or DLL path that contains MT5APIManager64.dll");
-
-        _manager = SMTManagerAPIFactory.CreateManager(SMTManagerAPIFactory.ManagerAPIVersion, out result);
-        ThrowIfFailed(result, "Create MT5 manager instance");
-
-        if (_manager is null)
-        {
-            throw new InvalidOperationException("MT5 Manager API returned MT_RET_OK but did not create a manager instance.");
-        }
-
-        result = _manager.Connect(
-            _options.Server,
-            _options.Login,
-            _options.Password,
-            null,
-            CIMTManagerAPI.EnPumpModes.PUMP_MODE_FULL,
-            _options.TimeoutMilliseconds);
-        ThrowIfFailed(result, $"Connect to MT5 server {_options.Server} as manager {_options.Login}");
-
-        _connected = true;
-        _logger.LogInformation("Connected to MT5 Manager server {Server} as manager login {Login}.", _options.Server, _options.Login);
-    }
-
-
-    private static MTRetCode InitializeManagerApi(string? configuredNativeLibraryPath)
-    {
-        var nativeDllPath = GetNativeManagerDllPath();
-        var candidates = new List<string?>();
-
-        if (!string.IsNullOrWhiteSpace(configuredNativeLibraryPath))
-        {
-            candidates.Add(configuredNativeLibraryPath);
-        }
-
-        if (!string.IsNullOrWhiteSpace(nativeDllPath))
-        {
-            candidates.Add(nativeDllPath);
-
-            var nativeDirectory = Path.GetDirectoryName(nativeDllPath);
-            if (!string.IsNullOrWhiteSpace(nativeDirectory))
-            {
-                candidates.Add(nativeDirectory);
-            }
-        }
-
-        candidates.Add(AppContext.BaseDirectory);
-        candidates.Add(string.Empty);
-        candidates.Add(null);
-
-        MTRetCode lastResult = MTRetCode.MT_RET_ERROR;
-        foreach (var candidate in candidates.Distinct(StringComparer.OrdinalIgnoreCase))
-        {
-            lastResult = SMTManagerAPIFactory.Initialize(candidate);
-            if (lastResult == MTRetCode.MT_RET_OK)
-            {
-                return lastResult;
-            }
-        }
-
-        return lastResult;
-    }
-
-    private static string? GetNativeManagerDllPath()
-    {
-        var baseDirectory = AppContext.BaseDirectory;
-        foreach (var fileName in new[] { "MT5APIManager64.dll", "MT5APIManager.dll" })
-        {
-            var path = Path.Combine(baseDirectory, fileName);
-            if (File.Exists(path))
-            {
-                return path;
-            }
-        }
-
-        return Directory.EnumerateFiles(baseDirectory, "MT5APIManager*.dll", SearchOption.AllDirectories)
-            .FirstOrDefault();
-    }
-
     public Mt5Snapshot GetTradeAndOrderSnapshot()
     {
-        if (TryGetSnapshotFromMetaTrader5NetApi(out var terminalSnapshot))
-        {
-            return terminalSnapshot;
-        }
-
-        Connect();
-        ArgumentNullException.ThrowIfNull(_manager);
-
-        var orders = ReadOrders(_manager).Take((int)_options.MaxRows).ToList();
-        var deals = ReadDeals(_manager).Take((int)_options.MaxRows).ToList();
-
-        return new Mt5Snapshot(orders, deals);
-    }
-
-    public void Dispose()
-    {
-        if (_manager is not null)
-        {
-            _manager.Disconnect();
-            _manager.Dispose();
-            _manager = null;
-        }
-
-        _connected = false;
-        SMTManagerAPIFactory.Shutdown();
-    }
-
-
-    private bool TryGetSnapshotFromMetaTrader5NetApi(out Mt5Snapshot snapshot)
-    {
-        snapshot = new Mt5Snapshot(Array.Empty<string>(), Array.Empty<string>());
-
         var assembly = AppDomain.CurrentDomain.GetAssemblies()
             .FirstOrDefault(a => a.GetName().Name?.Contains("MetaTrader5", StringComparison.OrdinalIgnoreCase) == true)
             ?? TryLoadAssembly("MetaTrader5.Net.API")
@@ -147,35 +25,38 @@ public sealed class Mt5ManagerClient : IDisposable
 
         if (assembly is null)
         {
-            return false;
+            throw new InvalidOperationException("MetaTrader5.Net.API assembly is not available. Ensure the MetaTrader5.Net.API package is restored and copied to the output folder.");
         }
 
         foreach (var apiType in assembly.GetTypes().Where(t => !t.IsAbstract && !t.IsInterface && t.GetConstructor(Type.EmptyTypes) is not null))
         {
             var api = Activator.CreateInstance(apiType);
-            if (api is null)
-            {
-                continue;
-            }
-
-            if (!TryConnectMetaTrader5NetApi(api))
+            if (api is null || !TryConnect(api))
             {
                 continue;
             }
 
             var from = DateTime.UtcNow.AddDays(-Math.Max(1, _options.DealHistoryDays));
             var to = DateTime.UtcNow;
-            var orders = InvokeFirstDataMethod(api, new[] { "OrdersGet", "Orders", "GetOrders", "PositionsGet", "Positions", "GetPositions" }, Array.Empty<object?>(), new object?[] { _options.OrderGroupMask });
-            var deals = InvokeFirstDataMethod(api, new[] { "HistoryDealsGet", "DealsGet", "GetDeals", "HistoryOrdersGet", "GetHistoryOrders" }, new object?[] { from, to }, new object?[] { from, to, _options.OrderGroupMask });
+            var orders = InvokeFirstDataMethod(api,
+                new[] { "OrdersGet", "Orders", "GetOrders", "PositionsGet", "Positions", "GetPositions" },
+                Array.Empty<object?>(),
+                new object?[] { _options.OrderGroupMask });
+            var deals = InvokeFirstDataMethod(api,
+                new[] { "HistoryDealsGet", "DealsGet", "GetDeals", "HistoryOrdersGet", "GetHistoryOrders" },
+                new object?[] { from, to },
+                new object?[] { from, to, _options.OrderGroupMask });
 
-            snapshot = new Mt5Snapshot(NormalizeRows(orders).Take((int)_options.MaxRows).ToList(), NormalizeRows(deals).Take((int)_options.MaxRows).ToList());
-            return true;
+            _logger.LogInformation("MT5 snapshot loaded with MetaTrader5.Net API type {ApiType}.", apiType.FullName);
+            return new Mt5Snapshot(
+                NormalizeRows(orders).Take((int)_options.MaxRows).ToList(),
+                NormalizeRows(deals).Take((int)_options.MaxRows).ToList());
         }
 
-        return false;
+        throw new InvalidOperationException("Unable to connect using MetaTrader5.Net.API with the configured MT5 credentials.");
     }
 
-    private bool TryConnectMetaTrader5NetApi(object api)
+    private bool TryConnect(object api)
     {
         var login = Convert.ToInt64(_options.Login);
         return IsSuccess(InvokeFirstDataMethod(api, new[] { "Initialize", "Init", "Connect", "Login" },
@@ -216,120 +97,16 @@ public sealed class Mt5ManagerClient : IDisposable
 
                 try
                 {
-                    return method.Invoke(target, ConvertArguments(method.GetParameters(), arguments!));
+                    return method.Invoke(target, ConvertArguments(method.GetParameters(), arguments));
                 }
                 catch
                 {
-                    // Try next overload/name.
+                    // Try the next overload/name.
                 }
             }
         }
 
         return null;
-    }
-
-    private static bool IsSuccess(object? result)
-    {
-        return result is null || result is true || (result is not bool && result is IConvertible convertible && convertible.ToInt64(System.Globalization.CultureInfo.InvariantCulture) == 0);
-    }
-
-    private static IEnumerable<string> NormalizeRows(object? value)
-    {
-        if (value is null)
-        {
-            return Array.Empty<string>();
-        }
-
-        if (value is System.Collections.IEnumerable enumerable && value is not string)
-        {
-            return enumerable.Cast<object?>().Where(item => item is not null).Select(item => SerializeObject(item!));
-        }
-
-        return new[] { SerializeObject(value) };
-    }
-
-    private IEnumerable<string> ReadOrders(CIMTManagerAPI manager)
-    {
-        var orders = manager.OrderCreateArray();
-        if (orders is null)
-        {
-            throw new InvalidOperationException("MT5 Manager API could not create an order array.");
-        }
-
-        try
-        {
-            var result = InvokeMt5Method(manager, new[] { "OrderRequestByGroup", "OrderGetByGroup", "OrderGet" }, _options.OrderGroupMask, orders);
-            ThrowIfFailed(result, $"Request MT5 open orders for group mask '{_options.OrderGroupMask}'");
-
-            foreach (var item in ReadArrayItems(orders))
-            {
-                yield return item;
-            }
-        }
-        finally
-        {
-            orders.Release();
-        }
-    }
-
-    private IEnumerable<string> ReadDeals(CIMTManagerAPI manager)
-    {
-        var deals = manager.DealCreateArray();
-        if (deals is null)
-        {
-            throw new InvalidOperationException("MT5 Manager API could not create a deal array.");
-        }
-
-        try
-        {
-            var to = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
-            var from = DateTimeOffset.UtcNow.AddDays(-Math.Max(1, _options.DealHistoryDays)).ToUnixTimeSeconds();
-            var result = _options.DealHistoryLogin is null
-                ? InvokeMt5Method(manager, new[] { "DealRequestByGroup", "DealGetByGroup", "DealRequest", "DealGet" }, _options.OrderGroupMask, from, to, deals)
-                : InvokeMt5Method(manager, new[] { "DealRequest", "DealGet" }, _options.DealHistoryLogin.Value, from, to, deals);
-
-            ThrowIfFailed(result, _options.DealHistoryLogin is null
-                ? $"Request MT5 deals for group mask '{_options.OrderGroupMask}'"
-                : $"Request MT5 deals for login {_options.DealHistoryLogin.Value}");
-
-            foreach (var item in ReadArrayItems(deals))
-            {
-                yield return item;
-            }
-        }
-        finally
-        {
-            deals.Release();
-        }
-    }
-
-
-    private static MTRetCode InvokeMt5Method(object target, IEnumerable<string> methodNames, params object[] arguments)
-    {
-        foreach (var methodName in methodNames)
-        {
-            var method = target.GetType()
-                .GetMethods(BindingFlags.Public | BindingFlags.Instance)
-                .FirstOrDefault(candidate => string.Equals(candidate.Name, methodName, StringComparison.OrdinalIgnoreCase)
-                    && ParametersMatch(candidate.GetParameters(), arguments));
-
-            if (method is null)
-            {
-                continue;
-            }
-
-            try
-            {
-                var result = method.Invoke(target, ConvertArguments(method.GetParameters(), arguments));
-                return ToMtRetCode(result);
-            }
-            catch
-            {
-                // Try the next candidate overload/name.
-            }
-        }
-
-        throw new InvalidOperationException($"None of the MT5 Manager API methods were found: {string.Join(", ", methodNames)}.");
     }
 
     private static bool ParametersMatch(ParameterInfo[] parameters, object?[] arguments)
@@ -376,41 +153,24 @@ public sealed class Mt5ManagerClient : IDisposable
         return converted;
     }
 
-    private static MTRetCode ToMtRetCode(object? result)
+    private static bool IsSuccess(object? result)
     {
-        if (result is MTRetCode retCode)
-        {
-            return retCode;
-        }
-
-        return (MTRetCode)Convert.ToUInt32(result ?? MTRetCode.MT_RET_OK);
+        return result is null || result is true || (result is not bool && result is IConvertible convertible && convertible.ToInt64(System.Globalization.CultureInfo.InvariantCulture) == 0);
     }
 
-    private static IEnumerable<string> ReadArrayItems(object array)
+    private static IEnumerable<string> NormalizeRows(object? value)
     {
-        var total = Convert.ToUInt32(array.GetType().GetMethod("Total")?.Invoke(array, null) ?? 0u);
-        var nextMethod = array.GetType().GetMethod("Next") ?? array.GetType().GetMethod("Get");
-        if (nextMethod is null)
+        if (value is null)
         {
-            yield break;
+            return Array.Empty<string>();
         }
 
-        for (uint index = 0; index < total; index++)
+        if (value is System.Collections.IEnumerable enumerable && value is not string)
         {
-            var item = nextMethod.Invoke(array, new object[] { index });
-            if (item is not null)
-            {
-                yield return SerializeObject(item);
-            }
+            return enumerable.Cast<object?>().Where(item => item is not null).Select(item => SerializeObject(item!));
         }
-    }
 
-    private static void ThrowIfFailed(MTRetCode result, string operation)
-    {
-        if (result != MTRetCode.MT_RET_OK)
-        {
-            throw new InvalidOperationException($"{operation} failed with MT5 return code {result}.");
-        }
+        return new[] { SerializeObject(value) };
     }
 
     private static string SerializeObject(object value)

--- a/OTS.Solution/OTS.WorkflowService/Mt5ManagerClient.cs
+++ b/OTS.Solution/OTS.WorkflowService/Mt5ManagerClient.cs
@@ -18,6 +18,7 @@ public sealed class Mt5ManagerClient : IDisposable
 
     private readonly Mt5ManagerOptions _options;
     private readonly ILogger<Mt5ManagerClient> _logger;
+    private object? _factory;
     private object? _manager;
     private bool _connected;
 
@@ -35,11 +36,12 @@ public sealed class Mt5ManagerClient : IDisposable
         }
 
         var assembly = LoadManagerAssembly();
-        var factory = GetFactoryType(assembly);
+        var factoryType = GetFactoryType(assembly);
+        _factory = Activator.CreateInstance(factoryType) ?? factoryType;
 
-        EnsureOk(Invoke(factory, "Initialize"), "Initialize");
-        var version = ReadApiVersion(factory);
-        _manager = CreateManager(factory, version);
+        InitializeFactory(_factory);
+        var version = ReadApiVersion(_factory);
+        _manager = CreateManager(_factory, version);
 
         var connectResult = Invoke(
             _manager,
@@ -79,13 +81,12 @@ public sealed class Mt5ManagerClient : IDisposable
         _manager = null;
         _connected = false;
 
-        var assembly = AppDomain.CurrentDomain.GetAssemblies()
-            .FirstOrDefault(a => a.GetName().Name?.Contains("MT5ManagerAPI", StringComparison.OrdinalIgnoreCase) == true);
-        var factory = assembly is null ? null : GetFactoryTypeOrDefault(assembly);
-        if (factory is not null)
+        if (_factory is not null)
         {
-            InvokeIfExists(factory, "Shutdown");
+            InvokeIfExists(_factory, "Shutdown");
         }
+
+        _factory = null;
     }
 
     private IEnumerable<string> ReadCurrentOrders(object manager)
@@ -190,18 +191,36 @@ public sealed class Mt5ManagerClient : IDisposable
         }
     }
 
-    private static uint ReadApiVersion(Type factory)
+    private static void InitializeFactory(object factory)
+    {
+        var nativeDllPath = GetNativeManagerDllPath();
+        object? result;
+        try
+        {
+            result = nativeDllPath is null
+                ? Invoke(factory, "Initialize", (string?)null)
+                : Invoke(factory, "Initialize", nativeDllPath);
+        }
+        catch (MissingMethodException)
+        {
+            result = Invoke(factory, "Initialize");
+        }
+
+        EnsureOk(result, "Initialize");
+    }
+
+    private static uint ReadApiVersion(object factory)
     {
         var invocation = InvokeWithOut(factory, "Version", typeof(uint));
         EnsureOk(invocation.ReturnValue, "Version");
         return invocation.OutValues.OfType<uint>().FirstOrDefault();
     }
 
-    private static object CreateManager(Type factory, uint version)
+    private static object CreateManager(object factory, uint version)
     {
         var invocation = InvokeWithOut(factory, "CreateManager", typeof(object), version);
-        EnsureOk(invocation.ReturnValue, "CreateManager");
-        return invocation.OutValues.FirstOrDefault(v => v is not null)
+        EnsureOk(invocation.OutValues.FirstOrDefault(), "CreateManager");
+        return invocation.ReturnValue
             ?? throw new InvalidOperationException("CreateManager succeeded but did not return a manager instance.");
     }
 
@@ -258,6 +277,29 @@ public sealed class Mt5ManagerClient : IDisposable
         {
             yield return path;
         }
+    }
+
+
+    private static string? GetNativeManagerDllPath()
+    {
+        var baseDirectory = AppContext.BaseDirectory;
+        var candidateNames = new[]
+        {
+            "MT5APIManager64.dll",
+            "MT5APIManager.dll"
+        };
+
+        foreach (var candidateName in candidateNames)
+        {
+            var path = Path.Combine(baseDirectory, candidateName);
+            if (File.Exists(path))
+            {
+                return path;
+            }
+        }
+
+        return Directory.EnumerateFiles(baseDirectory, "MT5APIManager*.dll", SearchOption.AllDirectories)
+            .FirstOrDefault();
     }
 
     private static Type GetFactoryType(Assembly assembly)

--- a/OTS.Solution/OTS.WorkflowService/Mt5ManagerClient.cs
+++ b/OTS.Solution/OTS.WorkflowService/Mt5ManagerClient.cs
@@ -58,16 +58,34 @@ public sealed class Mt5ManagerClient : IDisposable
     private static MTRetCode InitializeManagerApi()
     {
         var nativeDllPath = GetNativeManagerDllPath();
+        var candidates = new List<string?>();
+
         if (!string.IsNullOrWhiteSpace(nativeDllPath))
         {
-            var pathResult = SMTManagerAPIFactory.Initialize(nativeDllPath);
-            if (pathResult == MTRetCode.MT_RET_OK)
+            candidates.Add(nativeDllPath);
+
+            var nativeDirectory = Path.GetDirectoryName(nativeDllPath);
+            if (!string.IsNullOrWhiteSpace(nativeDirectory))
             {
-                return pathResult;
+                candidates.Add(nativeDirectory);
             }
         }
 
-        return SMTManagerAPIFactory.Initialize(null);
+        candidates.Add(AppContext.BaseDirectory);
+        candidates.Add(string.Empty);
+        candidates.Add(null);
+
+        MTRetCode lastResult = MTRetCode.MT_RET_ERROR;
+        foreach (var candidate in candidates.Distinct(StringComparer.OrdinalIgnoreCase))
+        {
+            lastResult = SMTManagerAPIFactory.Initialize(candidate);
+            if (lastResult == MTRetCode.MT_RET_OK)
+            {
+                return lastResult;
+            }
+        }
+
+        return lastResult;
     }
 
     private static string? GetNativeManagerDllPath()

--- a/OTS.Solution/OTS.WorkflowService/Mt5ManagerClient.cs
+++ b/OTS.Solution/OTS.WorkflowService/Mt5ManagerClient.cs
@@ -1,25 +1,17 @@
 using System.Reflection;
-using System.Runtime.Loader;
 using System.Text.Json;
+using MetaQuotes.MT5CommonAPI;
+using MetaQuotes.MT5ManagerAPI;
 
 namespace OTS.WorkflowService;
 
-/// <summary>
-/// Thin adapter over the MetaQuotes MT5 Manager .NET API.
-///
-/// The NuGet package exposes native-style classes (CMTManagerAPIFactory/CIMTManager)
-/// and methods that often use return codes plus out parameters. Reflection keeps this
-/// worker buildable in environments where the native Windows Manager API runtime is not
-/// installed, while still calling the real Manager API methods at runtime.
-/// </summary>
 public sealed class Mt5ManagerClient : IDisposable
 {
     private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = false };
 
     private readonly Mt5ManagerOptions _options;
     private readonly ILogger<Mt5ManagerClient> _logger;
-    private object? _factory;
-    private object? _manager;
+    private CIMTManagerAPI? _manager;
     private bool _connected;
 
     public Mt5ManagerClient(Mt5ManagerOptions options, ILogger<Mt5ManagerClient> logger)
@@ -35,27 +27,28 @@ public sealed class Mt5ManagerClient : IDisposable
             return;
         }
 
-        var assembly = LoadManagerAssembly();
-        var factoryType = GetFactoryType(assembly);
-        _factory = Activator.CreateInstance(factoryType) ?? factoryType;
+        var result = SMTManagerAPIFactory.Initialize(null);
+        ThrowIfFailed(result, "Initialize MT5 Manager API");
 
-        InitializeFactory(_factory);
-        var version = ReadApiVersionConstant(_factory) ?? 0;
-        _manager = CreateManager(_factory, version);
+        _manager = SMTManagerAPIFactory.CreateManager(SMTManagerAPIFactory.ManagerAPIVersion, out result);
+        ThrowIfFailed(result, "Create MT5 manager instance");
 
-        var connectResult = Invoke(
-            _manager,
-            "Connect",
+        if (_manager is null)
+        {
+            throw new InvalidOperationException("MT5 Manager API returned MT_RET_OK but did not create a manager instance.");
+        }
+
+        result = _manager.Connect(
             _options.Server,
             _options.Login,
             _options.Password,
             null,
-            (ulong)_options.PumpingMode,
+            CIMTManagerAPI.EnPumpModes.PUMP_MODE_FULL,
             _options.TimeoutMilliseconds);
-        EnsureOk(connectResult, "Connect");
+        ThrowIfFailed(result, $"Connect to MT5 server {_options.Server} as manager {_options.Login}");
 
         _connected = true;
-        _logger.LogInformation("Connected to MT5 Manager server {Server} as login {Login}.", _options.Server, _options.Login);
+        _logger.LogInformation("Connected to MT5 Manager server {Server} as manager login {Login}.", _options.Server, _options.Login);
     }
 
     public Mt5Snapshot GetTradeAndOrderSnapshot()
@@ -63,7 +56,7 @@ public sealed class Mt5ManagerClient : IDisposable
         Connect();
         ArgumentNullException.ThrowIfNull(_manager);
 
-        var orders = ReadCurrentOrders(_manager).Take((int)_options.MaxRows).ToList();
+        var orders = ReadOrders(_manager).Take((int)_options.MaxRows).ToList();
         var deals = ReadDeals(_manager).Take((int)_options.MaxRows).ToList();
 
         return new Mt5Snapshot(orders, deals);
@@ -73,117 +66,82 @@ public sealed class Mt5ManagerClient : IDisposable
     {
         if (_manager is not null)
         {
-            InvokeIfExists(_manager, "Disconnect");
-            InvokeIfExists(_manager, "Release");
-            (_manager as IDisposable)?.Dispose();
+            _manager.Disconnect();
+            _manager.Dispose();
+            _manager = null;
         }
 
-        _manager = null;
         _connected = false;
-
-        if (_factory is not null)
-        {
-            InvokeIfExists(_factory, "Shutdown");
-        }
-
-        _factory = null;
+        SMTManagerAPIFactory.Shutdown();
     }
 
-    private IEnumerable<string> ReadCurrentOrders(object manager)
+    private IEnumerable<string> ReadOrders(CIMTManagerAPI manager)
     {
-        foreach (var row in ReadCollectionFromCreateArrayRequest(manager, "OrderCreateArray", "OrderRequestByGroup", _options.OrderGroupMask))
+        var orders = manager.OrderCreateArray();
+        if (orders is null)
         {
-            yield return row;
+            throw new InvalidOperationException("MT5 Manager API could not create an order array.");
         }
 
-        foreach (var row in ReadCollectionByTotalAndNext(manager, "OrderGetTotal", "OrderGetNext"))
+        try
         {
-            yield return row;
+            var result = manager.OrderRequestByGroup(_options.OrderGroupMask, orders);
+            ThrowIfFailed(result, $"Request MT5 open orders for group mask '{_options.OrderGroupMask}'");
+
+            foreach (var item in ReadArrayItems(orders))
+            {
+                yield return item;
+            }
         }
-    }
-
-    private IEnumerable<string> ReadDeals(object manager)
-    {
-        if (_options.DealHistoryLogin is null)
+        finally
         {
-            _logger.LogInformation("Mt5Manager:DealHistoryLogin is not configured, so deal history request is skipped.");
-            yield break;
-        }
-
-        var to = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
-        var from = DateTimeOffset.UtcNow.AddDays(-Math.Max(1, _options.DealHistoryDays)).ToUnixTimeSeconds();
-
-        foreach (var row in ReadCollectionFromCreateArrayRequest(
-                     manager,
-                     "DealCreateArray",
-                     "DealRequest",
-                     _options.DealHistoryLogin.Value,
-                     from,
-                     to))
-        {
-            yield return row;
+            orders.Release();
         }
     }
 
-    private static IEnumerable<string> ReadCollectionFromCreateArrayRequest(object manager, string createArrayMethod, string requestMethod, params object?[] requestArguments)
+    private IEnumerable<string> ReadDeals(CIMTManagerAPI manager)
     {
-        var array = InvokeIfExists(manager, createArrayMethod);
-        if (array is null)
+        var deals = manager.DealCreateArray();
+        if (deals is null)
         {
-            yield break;
+            throw new InvalidOperationException("MT5 Manager API could not create a deal array.");
         }
 
-        var arguments = requestArguments.Concat(new[] { array }).ToArray();
-        EnsureOk(Invoke(manager, requestMethod, arguments), requestMethod);
-
-        foreach (var row in ReadArrayLikeObject(array))
+        try
         {
-            yield return row;
-        }
+            var to = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+            var from = DateTimeOffset.UtcNow.AddDays(-Math.Max(1, _options.DealHistoryDays)).ToUnixTimeSeconds();
+            var result = _options.DealHistoryLogin is null
+                ? manager.DealRequestByGroup(_options.OrderGroupMask, from, to, deals)
+                : manager.DealRequest(_options.DealHistoryLogin.Value, from, to, deals);
 
-        InvokeIfExists(array, "Release");
+            ThrowIfFailed(result, _options.DealHistoryLogin is null
+                ? $"Request MT5 deals for group mask '{_options.OrderGroupMask}'"
+                : $"Request MT5 deals for login {_options.DealHistoryLogin.Value}");
+
+            foreach (var item in ReadArrayItems(deals))
+            {
+                yield return item;
+            }
+        }
+        finally
+        {
+            deals.Release();
+        }
     }
 
-    private static IEnumerable<string> ReadCollectionByTotalAndNext(object manager, string totalMethod, string nextMethod)
+    private static IEnumerable<string> ReadArrayItems(object array)
     {
-        var totalObject = InvokeIfExists(manager, totalMethod);
-        if (totalObject is null || !TryToUInt(totalObject, out var total))
+        var total = Convert.ToUInt32(array.GetType().GetMethod("Total")?.Invoke(array, null) ?? 0u);
+        var nextMethod = array.GetType().GetMethod("Next") ?? array.GetType().GetMethod("Get");
+        if (nextMethod is null)
         {
             yield break;
         }
 
         for (uint index = 0; index < total; index++)
         {
-            var next = InvokeIfExists(manager, nextMethod, index);
-            if (next is not null)
-            {
-                yield return SerializeObject(next);
-            }
-        }
-    }
-
-    private static IEnumerable<string> ReadArrayLikeObject(object array)
-    {
-        if (array is System.Collections.IEnumerable enumerable && array is not string)
-        {
-            foreach (var item in enumerable)
-            {
-                yield return SerializeObject(item);
-            }
-
-            yield break;
-        }
-
-        var totalObject = InvokeIfExists(array, "Total");
-        if (totalObject is null || !TryToUInt(totalObject, out var total))
-        {
-            yield return SerializeObject(array);
-            yield break;
-        }
-
-        for (uint index = 0; index < total; index++)
-        {
-            var item = InvokeIfExists(array, "Next", index) ?? InvokeIfExists(array, "Get", index);
+            var item = nextMethod.Invoke(array, new object[] { index });
             if (item is not null)
             {
                 yield return SerializeObject(item);
@@ -191,436 +149,20 @@ public sealed class Mt5ManagerClient : IDisposable
         }
     }
 
-    private static void InitializeFactory(object factory)
+    private static void ThrowIfFailed(MTRetCode result, string operation)
     {
-        var nativeDllPath = GetNativeManagerDllPath();
-        var initializeResults = new[]
-            {
-                nativeDllPath is null ? null : InvokeIfExists(factory, "Initialize", nativeDllPath),
-                InvokeIfExists(factory, "Initialize", (string?)null),
-                InvokeIfExists(factory, "Initialize"),
-                nativeDllPath is null ? null : InvokeIfExists(factory, "Init", nativeDllPath),
-                InvokeIfExists(factory, "Init", (string?)null),
-                InvokeIfExists(factory, "Init")
-            }
-            .Where(result => result is not null)
-            .ToList();
-
-        if (initializeResults.Count == 0 || initializeResults.Any(IsOkReturnCode))
+        if (result != MTRetCode.MT_RET_OK)
         {
-            return;
-        }
-
-        // The MetaQuotes NuGet package variants used in deployments can return
-        // MT_RET_ERROR from Initialize when the native DLL is already loaded or when
-        // initialization is not required. Continue to Version/CreateManager/Connect,
-        // because those calls are the real validation for getting orders and deals
-        // with manager credentials.
-    }
-
-    private static object CreateManager(object factory, uint version)
-    {
-        if (version > 0)
-        {
-            var manager = TryCreateManager(factory, version);
-            if (manager is not null)
-            {
-                return manager;
-            }
-        }
-
-        return TryCreateManager(factory)
-            ?? TryCreateManagerWithoutOut(factory, version)
-            ?? TryCreateManagerWithoutOut(factory)
-            ?? throw new InvalidOperationException("Unable to create an MT5 manager instance from the MetaQuotes Manager API factory.");
-    }
-
-    private static object? TryCreateManager(object factory, params object?[] arguments)
-    {
-        try
-        {
-            var invocation = InvokeWithOut(factory, "CreateManager", typeof(object), arguments);
-            var outValue = invocation.OutValues.FirstOrDefault(v => v is not null);
-
-            if (LooksLikeReturnCode(invocation.ReturnValue) && outValue is not null)
-            {
-                EnsureOk(invocation.ReturnValue, "CreateManager");
-                return outValue;
-            }
-
-            if (LooksLikeReturnCode(outValue))
-            {
-                EnsureOk(outValue, "CreateManager");
-                return invocation.ReturnValue;
-            }
-
-            return invocation.ReturnValue ?? outValue;
-        }
-        catch
-        {
-            return null;
+            throw new InvalidOperationException($"{operation} failed with MT5 return code {result}.");
         }
     }
 
-    private static object? TryCreateManagerWithoutOut(object factory, params object?[] arguments)
+    private static string SerializeObject(object value)
     {
-        try
-        {
-            return Invoke(factory, "CreateManager", arguments);
-        }
-        catch
-        {
-            return null;
-        }
-    }
-
-    private static uint? ReadApiVersionConstant(object factory)
-    {
-        var type = factory as Type ?? factory.GetType();
-        var flags = BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static;
-
-        foreach (var property in type.GetProperties(flags).Where(p => IsVersionMember(p.Name)))
-        {
-            if (TryConvertToUInt(property.GetValue(factory is Type ? null : factory), out var version))
-            {
-                return version;
-            }
-        }
-
-        foreach (var field in type.GetFields(flags).Where(f => IsVersionMember(f.Name)))
-        {
-            if (TryConvertToUInt(field.GetValue(factory is Type ? null : factory), out var version))
-            {
-                return version;
-            }
-        }
-
-        return null;
-    }
-
-    private static bool IsVersionMember(string name)
-    {
-        return name.Contains("Version", StringComparison.OrdinalIgnoreCase)
-            && name.Contains("API", StringComparison.OrdinalIgnoreCase);
-    }
-
-    private static bool TryConvertToUInt(object? value, out uint result)
-    {
-        try
-        {
-            if (value is null)
-            {
-                result = 0;
-                return false;
-            }
-
-            result = Convert.ToUInt32(value);
-            return true;
-        }
-        catch
-        {
-            result = 0;
-            return false;
-        }
-    }
-
-    private static Assembly LoadManagerAssembly()
-    {
-        var loadedAssembly = AppDomain.CurrentDomain.GetAssemblies()
-            .FirstOrDefault(a => a.GetName().Name?.Contains("MT5ManagerAPI", StringComparison.OrdinalIgnoreCase) == true);
-        if (loadedAssembly is not null)
-        {
-            return loadedAssembly;
-        }
-
-        foreach (var assemblyPath in GetManagerAssemblyCandidates())
-        {
-            try
-            {
-                return AssemblyLoadContext.Default.LoadFromAssemblyPath(assemblyPath);
-            }
-            catch (FileLoadException)
-            {
-                return Assembly.LoadFrom(assemblyPath);
-            }
-            catch (BadImageFormatException)
-            {
-                // Ignore native helper DLLs; continue until the managed wrapper DLL is found.
-            }
-        }
-
-        throw new FileNotFoundException(
-            "Unable to locate the managed MT5 Manager API assembly. Ensure the MetaQuotes.MT5ManagerAPI64-net2.0 package DLLs are copied to the WorkflowService output folder.");
-    }
-
-    private static IEnumerable<string> GetManagerAssemblyCandidates()
-    {
-        var baseDirectory = AppContext.BaseDirectory;
-        var candidateNames = new[]
-        {
-            "MetaQuotes.MT5ManagerAPI64.dll",
-            "MetaQuotes.MT5ManagerAPI.dll",
-            "MT5ManagerAPI64.dll",
-            "MT5ManagerAPI.dll"
-        };
-
-        foreach (var candidateName in candidateNames)
-        {
-            var path = Path.Combine(baseDirectory, candidateName);
-            if (File.Exists(path))
-            {
-                yield return path;
-            }
-        }
-
-        foreach (var path in Directory.EnumerateFiles(baseDirectory, "*MT5*Manager*API*.dll", SearchOption.AllDirectories))
-        {
-            yield return path;
-        }
-    }
-
-
-    private static string? GetNativeManagerDllPath()
-    {
-        var baseDirectory = AppContext.BaseDirectory;
-        var candidateNames = new[]
-        {
-            "MT5APIManager64.dll",
-            "MT5APIManager.dll"
-        };
-
-        foreach (var candidateName in candidateNames)
-        {
-            var path = Path.Combine(baseDirectory, candidateName);
-            if (File.Exists(path))
-            {
-                return path;
-            }
-        }
-
-        return Directory.EnumerateFiles(baseDirectory, "MT5APIManager*.dll", SearchOption.AllDirectories)
-            .FirstOrDefault();
-    }
-
-    private static Type GetFactoryType(Assembly assembly)
-    {
-        return GetFactoryTypeOrDefault(assembly)
-            ?? throw new InvalidOperationException("Unable to find CMTManagerAPIFactory in the MetaQuotes MT5 Manager API assembly.");
-    }
-
-    private static Type? GetFactoryTypeOrDefault(Assembly assembly)
-    {
-        var types = assembly.GetTypes();
-        return types.FirstOrDefault(t => string.Equals(t.Name, "CMTManagerAPIFactory", StringComparison.OrdinalIgnoreCase) && HasMethod(t, "CreateManager"))
-            ?? types.FirstOrDefault(t => t.Name.Contains("ManagerAPIFactory", StringComparison.OrdinalIgnoreCase) && HasMethod(t, "CreateManager"))
-            ?? types.FirstOrDefault(t => t.Name.Contains("ManagerFactory", StringComparison.OrdinalIgnoreCase) && HasMethod(t, "CreateManager"));
-    }
-
-    private static bool HasMethod(Type type, string methodName)
-    {
-        return type.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static)
-            .Any(m => string.Equals(m.Name, methodName, StringComparison.OrdinalIgnoreCase));
-    }
-
-    private static object? InvokeIfExists(object target, string methodName, params object?[] arguments)
-    {
-        try
-        {
-            return Invoke(target, methodName, arguments);
-        }
-        catch (MissingMethodException)
-        {
-            return null;
-        }
-    }
-
-    private static object? Invoke(object target, string methodName, params object?[] arguments)
-    {
-        var type = target as Type ?? target.GetType();
-        var method = type.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static)
-            .FirstOrDefault(m => string.Equals(m.Name, methodName, StringComparison.OrdinalIgnoreCase) && ParametersMatch(m.GetParameters(), arguments));
-
-        if (method is null)
-        {
-            throw new MissingMethodException(type.FullName, methodName);
-        }
-
-        return method.Invoke(target is Type ? null : target, ConvertArguments(method.GetParameters(), arguments));
-    }
-
-    private static InvocationResult InvokeWithOut(object target, string methodName, Type outType, params object?[] inputArguments)
-    {
-        var type = target as Type ?? target.GetType();
-        var method = type.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static)
-            .FirstOrDefault(m => string.Equals(m.Name, methodName, StringComparison.OrdinalIgnoreCase)
-                && m.GetParameters().Length == inputArguments.Length + 1
-                && m.GetParameters().Last().ParameterType.IsByRef);
-
-        if (method is null)
-        {
-            throw new MissingMethodException(type.FullName, methodName);
-        }
-
-        var outParameterType = method.GetParameters().Last().ParameterType.GetElementType() ?? outType;
-        var arguments = inputArguments.Concat(new[] { GetDefault(outParameterType) }).ToArray();
-        var invokeArguments = ConvertArguments(method.GetParameters(), arguments);
-        var returnValue = method.Invoke(target is Type ? null : target, invokeArguments);
-        return new InvocationResult(returnValue, invokeArguments.Skip(inputArguments.Length).ToArray());
-    }
-
-
-    private static object?[] ConvertArguments(ParameterInfo[] parameters, object?[] arguments)
-    {
-        var converted = new object?[arguments.Length];
-        for (var i = 0; i < arguments.Length; i++)
-        {
-            if (arguments[i] is null || parameters[i].ParameterType.IsByRef)
-            {
-                converted[i] = arguments[i];
-                continue;
-            }
-
-            var parameterType = Nullable.GetUnderlyingType(parameters[i].ParameterType) ?? parameters[i].ParameterType;
-            converted[i] = parameterType.IsInstanceOfType(arguments[i])
-                ? arguments[i]
-                : Convert.ChangeType(arguments[i], parameterType, System.Globalization.CultureInfo.InvariantCulture);
-        }
-
-        return converted;
-    }
-
-    private static bool ParametersMatch(ParameterInfo[] parameters, object?[] arguments)
-    {
-        if (parameters.Length != arguments.Length)
-        {
-            return false;
-        }
-
-        for (var i = 0; i < parameters.Length; i++)
-        {
-            if (arguments[i] is null || parameters[i].ParameterType.IsByRef)
-            {
-                continue;
-            }
-
-            var parameterType = Nullable.GetUnderlyingType(parameters[i].ParameterType) ?? parameters[i].ParameterType;
-            if (!parameterType.IsInstanceOfType(arguments[i]) && !CanConvert(arguments[i]!, parameterType))
-            {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    private static bool CanConvert(object value, Type type)
-    {
-        return value is IConvertible && typeof(IConvertible).IsAssignableFrom(type);
-    }
-
-
-
-    private static bool LooksLikeReturnCode(object? value)
-    {
-        if (value is null)
-        {
-            return false;
-        }
-
-        var type = value.GetType();
-        return type.IsEnum || value is bool || IsNumericType(type);
-    }
-
-    private static bool IsNumericType(Type type)
-    {
-        type = Nullable.GetUnderlyingType(type) ?? type;
-        return type == typeof(byte)
-            || type == typeof(sbyte)
-            || type == typeof(short)
-            || type == typeof(ushort)
-            || type == typeof(int)
-            || type == typeof(uint)
-            || type == typeof(long)
-            || type == typeof(ulong);
-    }
-
-    private static bool IsOkReturnCode(object? returnValue)
-    {
-        if (returnValue is null)
-        {
-            return true;
-        }
-
-        if (returnValue is bool boolResult)
-        {
-            return boolResult;
-        }
-
-        if (returnValue is IConvertible convertible)
-        {
-            return convertible.ToInt64(System.Globalization.CultureInfo.InvariantCulture) == 0;
-        }
-
-        return true;
-    }
-
-    private static void EnsureOk(object? returnValue, string operation)
-    {
-        if (returnValue is null)
-        {
-            return;
-        }
-
-        if (returnValue is bool boolResult)
-        {
-            if (!boolResult)
-            {
-                throw new InvalidOperationException($"MT5 Manager API {operation} returned false.");
-            }
-
-            return;
-        }
-
-        if (returnValue is IConvertible convertible)
-        {
-            var code = convertible.ToInt64(System.Globalization.CultureInfo.InvariantCulture);
-            if (code != 0)
-            {
-                throw new InvalidOperationException($"MT5 Manager API {operation} failed with return code {returnValue}.");
-            }
-        }
-    }
-
-    private static bool TryToUInt(object value, out uint result)
-    {
-        try
-        {
-            result = Convert.ToUInt32(value);
-            return true;
-        }
-        catch
-        {
-            result = 0;
-            return false;
-        }
-    }
-
-    private static object? GetDefault(Type type)
-    {
-        return type.IsValueType ? Activator.CreateInstance(type) : null;
-    }
-
-    private static string SerializeObject(object? value)
-    {
-        if (value is null)
-        {
-            return "null";
-        }
-
         var members = value.GetType()
             .GetMethods(BindingFlags.Public | BindingFlags.Instance)
-            .Where(m => m.GetParameters().Length == 0 && m.ReturnType != typeof(void) && !m.IsSpecialName && m.Name != "GetHashCode")
-            .ToDictionary(m => m.Name, m => SafeInvoke(value, m));
+            .Where(method => method.GetParameters().Length == 0 && method.ReturnType != typeof(void) && !method.IsSpecialName && method.Name != nameof(GetHashCode))
+            .ToDictionary(method => method.Name, method => SafeInvoke(value, method));
 
         return members.Count == 0
             ? JsonSerializer.Serialize(value, value.GetType(), JsonOptions)
@@ -638,8 +180,6 @@ public sealed class Mt5ManagerClient : IDisposable
             return null;
         }
     }
-
-    private sealed record InvocationResult(object? ReturnValue, object?[] OutValues);
 }
 
 public sealed record Mt5Snapshot(IReadOnlyList<string> Orders, IReadOnlyList<string> Deals);

--- a/OTS.Solution/OTS.WorkflowService/Mt5ManagerClient.cs
+++ b/OTS.Solution/OTS.WorkflowService/Mt5ManagerClient.cs
@@ -194,23 +194,28 @@ public sealed class Mt5ManagerClient : IDisposable
     private static void InitializeFactory(object factory)
     {
         var nativeDllPath = GetNativeManagerDllPath();
-        object? result = InvokeIfExists(factory, "Initialize", nativeDllPath ?? AppContext.BaseDirectory)
-            ?? InvokeIfExists(factory, "Initialize", (string?)null)
-            ?? InvokeIfExists(factory, "Initialize")
-            ?? InvokeIfExists(factory, "Init", nativeDllPath ?? AppContext.BaseDirectory)
-            ?? InvokeIfExists(factory, "Init", (string?)null)
-            ?? InvokeIfExists(factory, "Init");
+        var initializeResults = new[]
+            {
+                nativeDllPath is null ? null : InvokeIfExists(factory, "Initialize", nativeDllPath),
+                InvokeIfExists(factory, "Initialize", (string?)null),
+                InvokeIfExists(factory, "Initialize"),
+                nativeDllPath is null ? null : InvokeIfExists(factory, "Init", nativeDllPath),
+                InvokeIfExists(factory, "Init", (string?)null),
+                InvokeIfExists(factory, "Init")
+            }
+            .Where(result => result is not null)
+            .ToList();
 
-        if (result is null)
+        if (initializeResults.Count == 0 || initializeResults.Any(IsOkReturnCode))
         {
-            // Some NuGet wrappers pre-load the native Manager API from the package output
-            // and expose only CreateManager/Version. Do not fail the workflow here; the
-            // following Version/CreateManager/Connect calls will validate whether the
-            // package can actually create a manager session.
             return;
         }
 
-        EnsureOk(result, "Initialize");
+        // The MetaQuotes NuGet package variants used in deployments can return
+        // MT_RET_ERROR from Initialize when the native DLL is already loaded or when
+        // initialization is not required. Continue to Version/CreateManager/Connect,
+        // because those calls are the real validation for getting orders and deals
+        // with manager credentials.
     }
 
     private static uint ReadApiVersion(object factory)
@@ -420,6 +425,27 @@ public sealed class Mt5ManagerClient : IDisposable
     private static bool CanConvert(object value, Type type)
     {
         return value is IConvertible && typeof(IConvertible).IsAssignableFrom(type);
+    }
+
+
+    private static bool IsOkReturnCode(object? returnValue)
+    {
+        if (returnValue is null)
+        {
+            return true;
+        }
+
+        if (returnValue is bool boolResult)
+        {
+            return boolResult;
+        }
+
+        if (returnValue is IConvertible convertible)
+        {
+            return convertible.ToInt64(System.Globalization.CultureInfo.InvariantCulture) == 0;
+        }
+
+        return true;
     }
 
     private static void EnsureOk(object? returnValue, string operation)

--- a/OTS.Solution/OTS.WorkflowService/Mt5ManagerClient.cs
+++ b/OTS.Solution/OTS.WorkflowService/Mt5ManagerClient.cs
@@ -27,11 +27,8 @@ public sealed class Mt5ManagerClient : IDisposable
             return;
         }
 
-        var result = InitializeManagerApi();
-        if (result != MTRetCode.MT_RET_OK)
-        {
-            _logger.LogWarning("Initialize MT5 Manager API returned {Result}; continuing to CreateManager because some package/runtime variants are already initialized.", result);
-        }
+        var result = InitializeManagerApi(_options.NativeLibraryPath);
+        ThrowIfFailed(result, "Initialize MT5 Manager API. If this fails, set Mt5Manager:NativeLibraryPath to the folder or DLL path that contains MT5APIManager64.dll");
 
         _manager = SMTManagerAPIFactory.CreateManager(SMTManagerAPIFactory.ManagerAPIVersion, out result);
         ThrowIfFailed(result, "Create MT5 manager instance");
@@ -55,10 +52,15 @@ public sealed class Mt5ManagerClient : IDisposable
     }
 
 
-    private static MTRetCode InitializeManagerApi()
+    private static MTRetCode InitializeManagerApi(string? configuredNativeLibraryPath)
     {
         var nativeDllPath = GetNativeManagerDllPath();
         var candidates = new List<string?>();
+
+        if (!string.IsNullOrWhiteSpace(configuredNativeLibraryPath))
+        {
+            candidates.Add(configuredNativeLibraryPath);
+        }
 
         if (!string.IsNullOrWhiteSpace(nativeDllPath))
         {

--- a/OTS.Solution/OTS.WorkflowService/Mt5ManagerClient.cs
+++ b/OTS.Solution/OTS.WorkflowService/Mt5ManagerClient.cs
@@ -220,17 +220,109 @@ public sealed class Mt5ManagerClient : IDisposable
 
     private static uint ReadApiVersion(object factory)
     {
-        var invocation = InvokeWithOut(factory, "Version", typeof(uint));
-        EnsureOk(invocation.ReturnValue, "Version");
-        return invocation.OutValues.OfType<uint>().FirstOrDefault();
+        try
+        {
+            var invocation = InvokeWithOut(factory, "Version", typeof(uint));
+            EnsureOk(invocation.ReturnValue, "Version");
+            return invocation.OutValues.OfType<uint>().FirstOrDefault();
+        }
+        catch (MissingMethodException)
+        {
+            return ReadApiVersionConstant(factory) ?? 0;
+        }
     }
 
     private static object CreateManager(object factory, uint version)
     {
-        var invocation = InvokeWithOut(factory, "CreateManager", typeof(object), version);
-        EnsureOk(invocation.OutValues.FirstOrDefault(), "CreateManager");
-        return invocation.ReturnValue
-            ?? throw new InvalidOperationException("CreateManager succeeded but did not return a manager instance.");
+        if (version > 0)
+        {
+            var manager = TryCreateManager(factory, version);
+            if (manager is not null)
+            {
+                return manager;
+            }
+        }
+
+        return TryCreateManager(factory)
+            ?? TryCreateManagerWithoutOut(factory, version)
+            ?? TryCreateManagerWithoutOut(factory)
+            ?? throw new InvalidOperationException("Unable to create an MT5 manager instance from the MetaQuotes Manager API factory.");
+    }
+
+    private static object? TryCreateManager(object factory, params object?[] arguments)
+    {
+        try
+        {
+            var invocation = InvokeWithOut(factory, "CreateManager", typeof(object), arguments);
+            EnsureOk(invocation.OutValues.FirstOrDefault(), "CreateManager");
+            return invocation.ReturnValue;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static object? TryCreateManagerWithoutOut(object factory, params object?[] arguments)
+    {
+        try
+        {
+            return Invoke(factory, "CreateManager", arguments);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static uint? ReadApiVersionConstant(object factory)
+    {
+        var type = factory as Type ?? factory.GetType();
+        var flags = BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static;
+
+        foreach (var property in type.GetProperties(flags).Where(p => IsVersionMember(p.Name)))
+        {
+            if (TryConvertToUInt(property.GetValue(factory is Type ? null : factory), out var version))
+            {
+                return version;
+            }
+        }
+
+        foreach (var field in type.GetFields(flags).Where(f => IsVersionMember(f.Name)))
+        {
+            if (TryConvertToUInt(field.GetValue(factory is Type ? null : factory), out var version))
+            {
+                return version;
+            }
+        }
+
+        return null;
+    }
+
+    private static bool IsVersionMember(string name)
+    {
+        return name.Contains("Version", StringComparison.OrdinalIgnoreCase)
+            && name.Contains("API", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool TryConvertToUInt(object? value, out uint result)
+    {
+        try
+        {
+            if (value is null)
+            {
+                result = 0;
+                return false;
+            }
+
+            result = Convert.ToUInt32(value);
+            return true;
+        }
+        catch
+        {
+            result = 0;
+            return false;
+        }
     }
 
     private static Assembly LoadManagerAssembly()

--- a/OTS.Solution/OTS.WorkflowService/Mt5ManagerClient.cs
+++ b/OTS.Solution/OTS.WorkflowService/Mt5ManagerClient.cs
@@ -27,8 +27,11 @@ public sealed class Mt5ManagerClient : IDisposable
             return;
         }
 
-        var result = SMTManagerAPIFactory.Initialize(null);
-        ThrowIfFailed(result, "Initialize MT5 Manager API");
+        var result = InitializeManagerApi();
+        if (result != MTRetCode.MT_RET_OK)
+        {
+            _logger.LogWarning("Initialize MT5 Manager API returned {Result}; continuing to CreateManager because some package/runtime variants are already initialized.", result);
+        }
 
         _manager = SMTManagerAPIFactory.CreateManager(SMTManagerAPIFactory.ManagerAPIVersion, out result);
         ThrowIfFailed(result, "Create MT5 manager instance");
@@ -49,6 +52,38 @@ public sealed class Mt5ManagerClient : IDisposable
 
         _connected = true;
         _logger.LogInformation("Connected to MT5 Manager server {Server} as manager login {Login}.", _options.Server, _options.Login);
+    }
+
+
+    private static MTRetCode InitializeManagerApi()
+    {
+        var nativeDllPath = GetNativeManagerDllPath();
+        if (!string.IsNullOrWhiteSpace(nativeDllPath))
+        {
+            var pathResult = SMTManagerAPIFactory.Initialize(nativeDllPath);
+            if (pathResult == MTRetCode.MT_RET_OK)
+            {
+                return pathResult;
+            }
+        }
+
+        return SMTManagerAPIFactory.Initialize(null);
+    }
+
+    private static string? GetNativeManagerDllPath()
+    {
+        var baseDirectory = AppContext.BaseDirectory;
+        foreach (var fileName in new[] { "MT5APIManager64.dll", "MT5APIManager.dll" })
+        {
+            var path = Path.Combine(baseDirectory, fileName);
+            if (File.Exists(path))
+            {
+                return path;
+            }
+        }
+
+        return Directory.EnumerateFiles(baseDirectory, "MT5APIManager*.dll", SearchOption.AllDirectories)
+            .FirstOrDefault();
     }
 
     public Mt5Snapshot GetTradeAndOrderSnapshot()

--- a/OTS.Solution/OTS.WorkflowService/Mt5ManagerClient.cs
+++ b/OTS.Solution/OTS.WorkflowService/Mt5ManagerClient.cs
@@ -85,7 +85,7 @@ public sealed class Mt5ManagerClient : IDisposable
 
         try
         {
-            var result = manager.OrderRequestByGroup(_options.OrderGroupMask, orders);
+            var result = InvokeMt5Method(manager, new[] { "OrderRequestByGroup", "OrderGetByGroup", "OrderGet" }, _options.OrderGroupMask, orders);
             ThrowIfFailed(result, $"Request MT5 open orders for group mask '{_options.OrderGroupMask}'");
 
             foreach (var item in ReadArrayItems(orders))
@@ -112,8 +112,8 @@ public sealed class Mt5ManagerClient : IDisposable
             var to = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
             var from = DateTimeOffset.UtcNow.AddDays(-Math.Max(1, _options.DealHistoryDays)).ToUnixTimeSeconds();
             var result = _options.DealHistoryLogin is null
-                ? manager.DealRequestByGroup(_options.OrderGroupMask, from, to, deals)
-                : manager.DealRequest(_options.DealHistoryLogin.Value, from, to, deals);
+                ? InvokeMt5Method(manager, new[] { "DealRequestByGroup", "DealGetByGroup", "DealRequest", "DealGet" }, _options.OrderGroupMask, from, to, deals)
+                : InvokeMt5Method(manager, new[] { "DealRequest", "DealGet" }, _options.DealHistoryLogin.Value, from, to, deals);
 
             ThrowIfFailed(result, _options.DealHistoryLogin is null
                 ? $"Request MT5 deals for group mask '{_options.OrderGroupMask}'"
@@ -128,6 +128,89 @@ public sealed class Mt5ManagerClient : IDisposable
         {
             deals.Release();
         }
+    }
+
+
+    private static MTRetCode InvokeMt5Method(object target, IEnumerable<string> methodNames, params object[] arguments)
+    {
+        foreach (var methodName in methodNames)
+        {
+            var method = target.GetType()
+                .GetMethods(BindingFlags.Public | BindingFlags.Instance)
+                .FirstOrDefault(candidate => string.Equals(candidate.Name, methodName, StringComparison.OrdinalIgnoreCase)
+                    && ParametersMatch(candidate.GetParameters(), arguments));
+
+            if (method is null)
+            {
+                continue;
+            }
+
+            try
+            {
+                var result = method.Invoke(target, ConvertArguments(method.GetParameters(), arguments));
+                return ToMtRetCode(result);
+            }
+            catch
+            {
+                // Try the next candidate overload/name.
+            }
+        }
+
+        throw new InvalidOperationException($"None of the MT5 Manager API methods were found: {string.Join(", ", methodNames)}.");
+    }
+
+    private static bool ParametersMatch(ParameterInfo[] parameters, object[] arguments)
+    {
+        if (parameters.Length != arguments.Length)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < parameters.Length; i++)
+        {
+            if (arguments[i] is null)
+            {
+                continue;
+            }
+
+            var parameterType = Nullable.GetUnderlyingType(parameters[i].ParameterType) ?? parameters[i].ParameterType;
+            if (!parameterType.IsInstanceOfType(arguments[i]) && !(arguments[i] is IConvertible && typeof(IConvertible).IsAssignableFrom(parameterType)))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static object?[] ConvertArguments(ParameterInfo[] parameters, object[] arguments)
+    {
+        var converted = new object?[arguments.Length];
+        for (var i = 0; i < arguments.Length; i++)
+        {
+            if (arguments[i] is null)
+            {
+                converted[i] = null;
+                continue;
+            }
+
+            var parameterType = Nullable.GetUnderlyingType(parameters[i].ParameterType) ?? parameters[i].ParameterType;
+            converted[i] = parameterType.IsInstanceOfType(arguments[i])
+                ? arguments[i]
+                : Convert.ChangeType(arguments[i], parameterType, System.Globalization.CultureInfo.InvariantCulture);
+        }
+
+        return converted;
+    }
+
+    private static MTRetCode ToMtRetCode(object? result)
+    {
+        if (result is MTRetCode retCode)
+        {
+            return retCode;
+        }
+
+        return (MTRetCode)Convert.ToUInt32(result ?? MTRetCode.MT_RET_OK);
     }
 
     private static IEnumerable<string> ReadArrayItems(object array)

--- a/OTS.Solution/OTS.WorkflowService/Mt5ManagerClient.cs
+++ b/OTS.Solution/OTS.WorkflowService/Mt5ManagerClient.cs
@@ -3,8 +3,18 @@ using System.Text.Json;
 
 namespace OTS.WorkflowService;
 
+/// <summary>
+/// Thin adapter over the MetaQuotes MT5 Manager .NET API.
+///
+/// The NuGet package exposes native-style classes (CMTManagerAPIFactory/CIMTManager)
+/// and methods that often use return codes plus out parameters. Reflection keeps this
+/// worker buildable in environments where the native Windows Manager API runtime is not
+/// installed, while still calling the real Manager API methods at runtime.
+/// </summary>
 public sealed class Mt5ManagerClient : IDisposable
 {
+    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = false };
+
     private readonly Mt5ManagerOptions _options;
     private readonly ILogger<Mt5ManagerClient> _logger;
     private object? _manager;
@@ -24,9 +34,23 @@ public sealed class Mt5ManagerClient : IDisposable
         }
 
         var assembly = LoadManagerAssembly();
-        InitializeFactory(assembly);
-        _manager = CreateManager(assembly);
-        InvokeByName(_manager, "Connect", _options.Server, _options.Login, _options.Password, null, _options.PumpingMode, _options.TimeoutMilliseconds);
+        var factory = GetFactoryType(assembly);
+
+        EnsureOk(Invoke(factory, "Initialize"), "Initialize");
+        var version = ReadApiVersion(factory);
+        _manager = CreateManager(factory, version);
+
+        var connectResult = Invoke(
+            _manager,
+            "Connect",
+            _options.Server,
+            _options.Login,
+            _options.Password,
+            null,
+            (ulong)_options.PumpingMode,
+            _options.TimeoutMilliseconds);
+        EnsureOk(connectResult, "Connect");
+
         _connected = true;
         _logger.LogInformation("Connected to MT5 Manager server {Server} as login {Login}.", _options.Server, _options.Login);
     }
@@ -36,39 +60,148 @@ public sealed class Mt5ManagerClient : IDisposable
         Connect();
         ArgumentNullException.ThrowIfNull(_manager);
 
-        var orders = InvokeFirstAvailable(_manager,
-            new[] { "OrderGet", "OrdersGet", "OrderGetAll", "OrderGetPage", "OrdersGetPage" },
-            new object?[][]
-            {
-                Array.Empty<object?>(),
-                new object?[] { _options.PreviewCount },
-                new object?[] { 0u, _options.PreviewCount },
-                new object?[] { 0UL, _options.PreviewCount }
-            });
+        var orders = ReadCurrentOrders(_manager).Take((int)_options.MaxRows).ToList();
+        var deals = ReadDeals(_manager).Take((int)_options.MaxRows).ToList();
 
-        var trades = InvokeFirstAvailable(_manager,
-            new[] { "DealGet", "DealsGet", "DealGetAll", "TradeGet", "TradesGet", "PositionGet", "PositionsGet" },
-            new object?[][]
-            {
-                Array.Empty<object?>(),
-                new object?[] { _options.PreviewCount },
-                new object?[] { 0u, _options.PreviewCount },
-                new object?[] { 0UL, _options.PreviewCount }
-            });
-
-        return new Mt5Snapshot(Normalize(orders), Normalize(trades));
+        return new Mt5Snapshot(orders, deals);
     }
 
     public void Dispose()
     {
-        if (_manager is null)
+        if (_manager is not null)
         {
-            return;
+            InvokeIfExists(_manager, "Disconnect");
+            InvokeIfExists(_manager, "Release");
+            (_manager as IDisposable)?.Dispose();
         }
 
-        InvokeOptional(_manager, "Disconnect");
-        (_manager as IDisposable)?.Dispose();
+        _manager = null;
         _connected = false;
+
+        var assembly = AppDomain.CurrentDomain.GetAssemblies()
+            .FirstOrDefault(a => a.GetName().Name?.Contains("MT5ManagerAPI", StringComparison.OrdinalIgnoreCase) == true);
+        var factory = assembly is null ? null : GetFactoryTypeOrDefault(assembly);
+        if (factory is not null)
+        {
+            InvokeIfExists(factory, "Shutdown");
+        }
+    }
+
+    private IEnumerable<string> ReadCurrentOrders(object manager)
+    {
+        foreach (var row in ReadCollectionFromCreateArrayRequest(manager, "OrderCreateArray", "OrderRequestByGroup", _options.OrderGroupMask))
+        {
+            yield return row;
+        }
+
+        foreach (var row in ReadCollectionByTotalAndNext(manager, "OrderGetTotal", "OrderGetNext"))
+        {
+            yield return row;
+        }
+    }
+
+    private IEnumerable<string> ReadDeals(object manager)
+    {
+        if (_options.DealHistoryLogin is null)
+        {
+            _logger.LogInformation("Mt5Manager:DealHistoryLogin is not configured, so deal history request is skipped.");
+            yield break;
+        }
+
+        var to = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+        var from = DateTimeOffset.UtcNow.AddDays(-Math.Max(1, _options.DealHistoryDays)).ToUnixTimeSeconds();
+
+        foreach (var row in ReadCollectionFromCreateArrayRequest(
+                     manager,
+                     "DealCreateArray",
+                     "DealRequest",
+                     _options.DealHistoryLogin.Value,
+                     from,
+                     to))
+        {
+            yield return row;
+        }
+    }
+
+    private static IEnumerable<string> ReadCollectionFromCreateArrayRequest(object manager, string createArrayMethod, string requestMethod, params object?[] requestArguments)
+    {
+        var array = InvokeIfExists(manager, createArrayMethod);
+        if (array is null)
+        {
+            yield break;
+        }
+
+        var arguments = requestArguments.Concat(new[] { array }).ToArray();
+        EnsureOk(Invoke(manager, requestMethod, arguments), requestMethod);
+
+        foreach (var row in ReadArrayLikeObject(array))
+        {
+            yield return row;
+        }
+
+        InvokeIfExists(array, "Release");
+    }
+
+    private static IEnumerable<string> ReadCollectionByTotalAndNext(object manager, string totalMethod, string nextMethod)
+    {
+        var totalObject = InvokeIfExists(manager, totalMethod);
+        if (totalObject is null || !TryToUInt(totalObject, out var total))
+        {
+            yield break;
+        }
+
+        for (uint index = 0; index < total; index++)
+        {
+            var next = InvokeIfExists(manager, nextMethod, index);
+            if (next is not null)
+            {
+                yield return SerializeObject(next);
+            }
+        }
+    }
+
+    private static IEnumerable<string> ReadArrayLikeObject(object array)
+    {
+        if (array is System.Collections.IEnumerable enumerable && array is not string)
+        {
+            foreach (var item in enumerable)
+            {
+                yield return SerializeObject(item);
+            }
+
+            yield break;
+        }
+
+        var totalObject = InvokeIfExists(array, "Total");
+        if (totalObject is null || !TryToUInt(totalObject, out var total))
+        {
+            yield return SerializeObject(array);
+            yield break;
+        }
+
+        for (uint index = 0; index < total; index++)
+        {
+            var item = InvokeIfExists(array, "Next", index) ?? InvokeIfExists(array, "Get", index);
+            if (item is not null)
+            {
+                yield return SerializeObject(item);
+            }
+        }
+    }
+
+    private static uint ReadApiVersion(Type factory)
+    {
+        var invocation = InvokeWithOut(factory, "Version", typeof(uint));
+        EnsureOk(invocation.ReturnValue, "Version");
+        return invocation.OutValues.OfType<uint>().FirstOrDefault();
+    }
+
+    private static object CreateManager(Type factory, uint version)
+    {
+        var invocation = InvokeWithOut(factory, "CreateManager", typeof(object), version);
+        EnsureOk(invocation.ReturnValue, "CreateManager");
+        return invocation.OutValues.FirstOrDefault(v => v is not null)
+            ?? throw new InvalidOperationException("CreateManager succeeded but did not return a manager instance.");
     }
 
     private static Assembly LoadManagerAssembly()
@@ -78,61 +211,22 @@ public sealed class Mt5ManagerClient : IDisposable
                ?? Assembly.Load("MetaQuotes.MT5ManagerAPI64-net2.0");
     }
 
-    private static void InitializeFactory(Assembly assembly)
+    private static Type GetFactoryType(Assembly assembly)
     {
-        var factory = assembly.GetTypes().FirstOrDefault(t => t.Name.Contains("Factory", StringComparison.OrdinalIgnoreCase));
-        if (factory is null)
-        {
-            return;
-        }
-
-        InvokeOptional(factory, "Initialize");
-        InvokeOptional(factory, "Init");
+        return GetFactoryTypeOrDefault(assembly)
+            ?? throw new InvalidOperationException("Unable to find CMTManagerAPIFactory in the MetaQuotes MT5 Manager API assembly.");
     }
 
-    private static object CreateManager(Assembly assembly)
+    private static Type? GetFactoryTypeOrDefault(Assembly assembly)
     {
-        var factory = assembly.GetTypes().FirstOrDefault(t => t.Name.Contains("Factory", StringComparison.OrdinalIgnoreCase));
-        if (factory is not null)
-        {
-            foreach (var methodName in new[] { "CreateManager", "Create", "ManagerCreate" })
-            {
-                var manager = InvokeOptional(factory, methodName);
-                if (manager is not null)
-                {
-                    return manager;
-                }
-            }
-        }
-
-        var managerType = assembly.GetTypes().FirstOrDefault(t => t.Name.Contains("Manager", StringComparison.OrdinalIgnoreCase) && !t.IsInterface && t.GetConstructor(Type.EmptyTypes) is not null)
-            ?? throw new InvalidOperationException("Unable to find an MT5 manager type in the MetaQuotes assembly.");
-
-        return Activator.CreateInstance(managerType)!;
+        return assembly.GetTypes().FirstOrDefault(t => string.Equals(t.Name, "CMTManagerAPIFactory", StringComparison.OrdinalIgnoreCase));
     }
 
-    private static object? InvokeFirstAvailable(object target, IEnumerable<string> methodNames, IEnumerable<object?[]> argumentSets)
-    {
-        foreach (var methodName in methodNames)
-        {
-            foreach (var arguments in argumentSets)
-            {
-                var value = InvokeOptional(target, methodName, arguments);
-                if (value is not null)
-                {
-                    return value;
-                }
-            }
-        }
-
-        throw new MissingMethodException("No compatible MT5 manager method was found for reading orders/trades.");
-    }
-
-    private static object? InvokeOptional(object target, string methodName, params object?[] arguments)
+    private static object? InvokeIfExists(object target, string methodName, params object?[] arguments)
     {
         try
         {
-            return InvokeByName(target, methodName, arguments);
+            return Invoke(target, methodName, arguments);
         }
         catch (MissingMethodException)
         {
@@ -140,40 +234,166 @@ public sealed class Mt5ManagerClient : IDisposable
         }
     }
 
-    private static object? InvokeByName(object target, string methodName, params object?[] arguments)
+    private static object? Invoke(object target, string methodName, params object?[] arguments)
     {
         var type = target as Type ?? target.GetType();
-        var flags = BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static;
-        var method = type.GetMethods(flags)
-            .FirstOrDefault(m => string.Equals(m.Name, methodName, StringComparison.OrdinalIgnoreCase) && m.GetParameters().Length == arguments.Length);
+        var method = type.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static)
+            .FirstOrDefault(m => string.Equals(m.Name, methodName, StringComparison.OrdinalIgnoreCase) && ParametersMatch(m.GetParameters(), arguments));
 
         if (method is null)
         {
             throw new MissingMethodException(type.FullName, methodName);
         }
 
-        return method.Invoke(target is Type ? null : target, arguments);
+        return method.Invoke(target is Type ? null : target, ConvertArguments(method.GetParameters(), arguments));
     }
 
-    private static IReadOnlyList<string> Normalize(object? value)
+    private static InvocationResult InvokeWithOut(object target, string methodName, Type outType, params object?[] inputArguments)
+    {
+        var type = target as Type ?? target.GetType();
+        var method = type.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static)
+            .FirstOrDefault(m => string.Equals(m.Name, methodName, StringComparison.OrdinalIgnoreCase)
+                && m.GetParameters().Length == inputArguments.Length + 1
+                && m.GetParameters().Last().ParameterType.IsByRef);
+
+        if (method is null)
+        {
+            throw new MissingMethodException(type.FullName, methodName);
+        }
+
+        var outParameterType = method.GetParameters().Last().ParameterType.GetElementType() ?? outType;
+        var arguments = inputArguments.Concat(new[] { GetDefault(outParameterType) }).ToArray();
+        var invokeArguments = ConvertArguments(method.GetParameters(), arguments);
+        var returnValue = method.Invoke(target is Type ? null : target, invokeArguments);
+        return new InvocationResult(returnValue, invokeArguments.Skip(inputArguments.Length).ToArray());
+    }
+
+
+    private static object?[] ConvertArguments(ParameterInfo[] parameters, object?[] arguments)
+    {
+        var converted = new object?[arguments.Length];
+        for (var i = 0; i < arguments.Length; i++)
+        {
+            if (arguments[i] is null || parameters[i].ParameterType.IsByRef)
+            {
+                converted[i] = arguments[i];
+                continue;
+            }
+
+            var parameterType = Nullable.GetUnderlyingType(parameters[i].ParameterType) ?? parameters[i].ParameterType;
+            converted[i] = parameterType.IsInstanceOfType(arguments[i])
+                ? arguments[i]
+                : Convert.ChangeType(arguments[i], parameterType, System.Globalization.CultureInfo.InvariantCulture);
+        }
+
+        return converted;
+    }
+
+    private static bool ParametersMatch(ParameterInfo[] parameters, object?[] arguments)
+    {
+        if (parameters.Length != arguments.Length)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < parameters.Length; i++)
+        {
+            if (arguments[i] is null || parameters[i].ParameterType.IsByRef)
+            {
+                continue;
+            }
+
+            var parameterType = Nullable.GetUnderlyingType(parameters[i].ParameterType) ?? parameters[i].ParameterType;
+            if (!parameterType.IsInstanceOfType(arguments[i]) && !CanConvert(arguments[i]!, parameterType))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool CanConvert(object value, Type type)
+    {
+        return value is IConvertible && typeof(IConvertible).IsAssignableFrom(type);
+    }
+
+    private static void EnsureOk(object? returnValue, string operation)
+    {
+        if (returnValue is null)
+        {
+            return;
+        }
+
+        if (returnValue is bool boolResult)
+        {
+            if (!boolResult)
+            {
+                throw new InvalidOperationException($"MT5 Manager API {operation} returned false.");
+            }
+
+            return;
+        }
+
+        if (returnValue is IConvertible convertible)
+        {
+            var code = convertible.ToInt64(System.Globalization.CultureInfo.InvariantCulture);
+            if (code != 0)
+            {
+                throw new InvalidOperationException($"MT5 Manager API {operation} failed with return code {returnValue}.");
+            }
+        }
+    }
+
+    private static bool TryToUInt(object value, out uint result)
+    {
+        try
+        {
+            result = Convert.ToUInt32(value);
+            return true;
+        }
+        catch
+        {
+            result = 0;
+            return false;
+        }
+    }
+
+    private static object? GetDefault(Type type)
+    {
+        return type.IsValueType ? Activator.CreateInstance(type) : null;
+    }
+
+    private static string SerializeObject(object? value)
     {
         if (value is null)
         {
-            return Array.Empty<string>();
+            return "null";
         }
 
-        if (value is System.Collections.IEnumerable enumerable && value is not string)
-        {
-            return enumerable.Cast<object?>().Select(Serialize).ToList();
-        }
+        var members = value.GetType()
+            .GetMethods(BindingFlags.Public | BindingFlags.Instance)
+            .Where(m => m.GetParameters().Length == 0 && m.ReturnType != typeof(void) && !m.IsSpecialName && m.Name != "GetHashCode")
+            .ToDictionary(m => m.Name, m => SafeInvoke(value, m));
 
-        return new[] { Serialize(value) };
+        return members.Count == 0
+            ? JsonSerializer.Serialize(value, value.GetType(), JsonOptions)
+            : JsonSerializer.Serialize(members, JsonOptions);
     }
 
-    private static string Serialize(object? value)
+    private static object? SafeInvoke(object target, MethodInfo method)
     {
-        return JsonSerializer.Serialize(value, value?.GetType() ?? typeof(object), new JsonSerializerOptions { WriteIndented = false });
+        try
+        {
+            return method.Invoke(target, null);
+        }
+        catch
+        {
+            return null;
+        }
     }
+
+    private sealed record InvocationResult(object? ReturnValue, object?[] OutValues);
 }
 
-public sealed record Mt5Snapshot(IReadOnlyList<string> Orders, IReadOnlyList<string> Trades);
+public sealed record Mt5Snapshot(IReadOnlyList<string> Orders, IReadOnlyList<string> Deals);

--- a/OTS.Solution/OTS.WorkflowService/Mt5ManagerClient.cs
+++ b/OTS.Solution/OTS.WorkflowService/Mt5ManagerClient.cs
@@ -240,8 +240,21 @@ public sealed class Mt5ManagerClient : IDisposable
         try
         {
             var invocation = InvokeWithOut(factory, "CreateManager", typeof(object), arguments);
-            EnsureOk(invocation.OutValues.FirstOrDefault(), "CreateManager");
-            return invocation.ReturnValue;
+            var outValue = invocation.OutValues.FirstOrDefault(v => v is not null);
+
+            if (LooksLikeReturnCode(invocation.ReturnValue) && outValue is not null)
+            {
+                EnsureOk(invocation.ReturnValue, "CreateManager");
+                return outValue;
+            }
+
+            if (LooksLikeReturnCode(outValue))
+            {
+                EnsureOk(outValue, "CreateManager");
+                return invocation.ReturnValue;
+            }
+
+            return invocation.ReturnValue ?? outValue;
         }
         catch
         {
@@ -505,6 +518,31 @@ public sealed class Mt5ManagerClient : IDisposable
         return value is IConvertible && typeof(IConvertible).IsAssignableFrom(type);
     }
 
+
+
+    private static bool LooksLikeReturnCode(object? value)
+    {
+        if (value is null)
+        {
+            return false;
+        }
+
+        var type = value.GetType();
+        return type.IsEnum || value is bool || IsNumericType(type);
+    }
+
+    private static bool IsNumericType(Type type)
+    {
+        type = Nullable.GetUnderlyingType(type) ?? type;
+        return type == typeof(byte)
+            || type == typeof(sbyte)
+            || type == typeof(short)
+            || type == typeof(ushort)
+            || type == typeof(int)
+            || type == typeof(uint)
+            || type == typeof(long)
+            || type == typeof(ulong);
+    }
 
     private static bool IsOkReturnCode(object? returnValue)
     {

--- a/OTS.Solution/OTS.WorkflowService/Mt5ManagerOptions.cs
+++ b/OTS.Solution/OTS.WorkflowService/Mt5ManagerOptions.cs
@@ -9,4 +9,8 @@ public sealed class Mt5ManagerOptions
     public uint TimeoutMilliseconds { get; set; } = 60_000;
     public int PollIntervalSeconds { get; set; } = 30;
     public uint PreviewCount { get; set; } = 10;
+    public uint MaxRows { get; set; } = 100;
+    public string OrderGroupMask { get; set; } = "*";
+    public ulong? DealHistoryLogin { get; set; }
+    public int DealHistoryDays { get; set; } = 1;
 }

--- a/OTS.Solution/OTS.WorkflowService/Mt5ManagerOptions.cs
+++ b/OTS.Solution/OTS.WorkflowService/Mt5ManagerOptions.cs
@@ -5,7 +5,6 @@ public sealed class Mt5ManagerOptions
     public string Server { get; set; } = string.Empty;
     public ulong Login { get; set; }
     public string Password { get; set; } = string.Empty;
-    public string? NativeLibraryPath { get; set; }
     public int PumpingMode { get; set; } = 0;
     public uint TimeoutMilliseconds { get; set; } = 60_000;
     public int PollIntervalSeconds { get; set; } = 30;

--- a/OTS.Solution/OTS.WorkflowService/Mt5ManagerOptions.cs
+++ b/OTS.Solution/OTS.WorkflowService/Mt5ManagerOptions.cs
@@ -1,0 +1,12 @@
+namespace OTS.WorkflowService;
+
+public sealed class Mt5ManagerOptions
+{
+    public string Server { get; set; } = string.Empty;
+    public ulong Login { get; set; }
+    public string Password { get; set; } = string.Empty;
+    public int PumpingMode { get; set; } = 0;
+    public uint TimeoutMilliseconds { get; set; } = 60_000;
+    public int PollIntervalSeconds { get; set; } = 30;
+    public uint PreviewCount { get; set; } = 10;
+}

--- a/OTS.Solution/OTS.WorkflowService/Mt5ManagerOptions.cs
+++ b/OTS.Solution/OTS.WorkflowService/Mt5ManagerOptions.cs
@@ -5,6 +5,7 @@ public sealed class Mt5ManagerOptions
     public string Server { get; set; } = string.Empty;
     public ulong Login { get; set; }
     public string Password { get; set; } = string.Empty;
+    public string? NativeLibraryPath { get; set; }
     public int PumpingMode { get; set; } = 0;
     public uint TimeoutMilliseconds { get; set; } = 60_000;
     public int PollIntervalSeconds { get; set; } = 30;

--- a/OTS.Solution/OTS.WorkflowService/OTS.WorkflowService.csproj
+++ b/OTS.Solution/OTS.WorkflowService/OTS.WorkflowService.csproj
@@ -4,7 +4,10 @@
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <PlatformTarget>x64</PlatformTarget>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <PackageReference Include="MetaTrader5.Net.API" Version="1.0.2" />
+
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <UserSecretsId>dotnet-OTS.WorkflowService-038de91f-eea7-42cc-bca5-aec7a6daa628</UserSecretsId>
   </PropertyGroup>

--- a/OTS.Solution/OTS.WorkflowService/OTS.WorkflowService.csproj
+++ b/OTS.Solution/OTS.WorkflowService/OTS.WorkflowService.csproj
@@ -10,15 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MetaQuotes.MT5ManagerAPI64-net2.0" Version="1755.0.0" />
     <PackageReference Include="MetaTrader5.Net.API" Version="1.0.2" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
   </ItemGroup>
 
-  <Target Name="CopyMt5NativeRuntime" AfterTargets="Build">
-    <ItemGroup>
-      <Mt5NativeRuntime Include="$(NuGetPackageRoot)metaquotes.mt5managerapi64-net2.0\1755.0.0\**\MT5APIManager*.dll" />
-    </ItemGroup>
-    <Copy SourceFiles="@(Mt5NativeRuntime)" DestinationFolder="$(OutDir)" SkipUnchangedFiles="true" Condition="@(Mt5NativeRuntime) != ''" />
-  </Target>
 </Project>

--- a/OTS.Solution/OTS.WorkflowService/OTS.WorkflowService.csproj
+++ b/OTS.Solution/OTS.WorkflowService/OTS.WorkflowService.csproj
@@ -1,9 +1,10 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
+<Project Sdk="Microsoft.NET.Sdk.Worker">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <PlatformTarget>x64</PlatformTarget>
     <UserSecretsId>dotnet-OTS.WorkflowService-038de91f-eea7-42cc-bca5-aec7a6daa628</UserSecretsId>
   </PropertyGroup>
 

--- a/OTS.Solution/OTS.WorkflowService/OTS.WorkflowService.csproj
+++ b/OTS.Solution/OTS.WorkflowService/OTS.WorkflowService.csproj
@@ -13,4 +13,11 @@
     <PackageReference Include="MetaQuotes.MT5ManagerAPI64-net2.0" Version="1755.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
   </ItemGroup>
+
+  <Target Name="CopyMt5NativeRuntime" AfterTargets="Build">
+    <ItemGroup>
+      <Mt5NativeRuntime Include="$(NuGetPackageRoot)metaquotes.mt5managerapi64-net2.0\1755.0.0\**\MT5APIManager*.dll" />
+    </ItemGroup>
+    <Copy SourceFiles="@(Mt5NativeRuntime)" DestinationFolder="$(OutDir)" SkipUnchangedFiles="true" Condition="@(Mt5NativeRuntime) != ''" />
+  </Target>
 </Project>

--- a/OTS.Solution/OTS.WorkflowService/OTS.WorkflowService.csproj
+++ b/OTS.Solution/OTS.WorkflowService/OTS.WorkflowService.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <PackageReference Include="MetaTrader5.Net.API" Version="1.0.2" />
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <UserSecretsId>dotnet-OTS.WorkflowService-038de91f-eea7-42cc-bca5-aec7a6daa628</UserSecretsId>
   </PropertyGroup>

--- a/OTS.Solution/OTS.WorkflowService/OTS.WorkflowService.csproj
+++ b/OTS.Solution/OTS.WorkflowService/OTS.WorkflowService.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <PlatformTarget>x64</PlatformTarget>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <UserSecretsId>dotnet-OTS.WorkflowService-038de91f-eea7-42cc-bca5-aec7a6daa628</UserSecretsId>
   </PropertyGroup>

--- a/OTS.Solution/OTS.WorkflowService/OTS.WorkflowService.csproj
+++ b/OTS.Solution/OTS.WorkflowService/OTS.WorkflowService.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="MetaQuotes.MT5ManagerAPI64-net2.0" Version="1755.0.0" />
+    <PackageReference Include="MetaTrader5.Net.API" Version="1.0.2" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
   </ItemGroup>
 

--- a/OTS.Solution/OTS.WorkflowService/OTS.WorkflowService.csproj
+++ b/OTS.Solution/OTS.WorkflowService/OTS.WorkflowService.csproj
@@ -5,6 +5,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <PlatformTarget>x64</PlatformTarget>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <UserSecretsId>dotnet-OTS.WorkflowService-038de91f-eea7-42cc-bca5-aec7a6daa628</UserSecretsId>
   </PropertyGroup>
 

--- a/OTS.Solution/OTS.WorkflowService/Program.cs
+++ b/OTS.Solution/OTS.WorkflowService/Program.cs
@@ -1,6 +1,9 @@
 using OTS.WorkflowService;
 
 var builder = Host.CreateApplicationBuilder(args);
+builder.Services.Configure<Mt5ManagerOptions>(builder.Configuration.GetSection("Mt5Manager"));
+builder.Services.AddSingleton(provider => provider.GetRequiredService<Microsoft.Extensions.Options.IOptions<Mt5ManagerOptions>>().Value);
+builder.Services.AddSingleton<Mt5ManagerClient>();
 builder.Services.AddHostedService<Worker>();
 
 var host = builder.Build();

--- a/OTS.Solution/OTS.WorkflowService/Program.cs
+++ b/OTS.Solution/OTS.WorkflowService/Program.cs
@@ -4,6 +4,9 @@ var builder = Host.CreateApplicationBuilder(args);
 builder.Services.Configure<Mt5ManagerOptions>(builder.Configuration.GetSection("Mt5Manager"));
 builder.Services.AddSingleton(provider => provider.GetRequiredService<Microsoft.Extensions.Options.IOptions<Mt5ManagerOptions>>().Value);
 builder.Services.AddSingleton<Mt5ManagerClient>();
+builder.Services.Configure<Mt5ManagerOptions>(builder.Configuration.GetSection("Mt5Manager"));
+builder.Services.AddSingleton(provider => provider.GetRequiredService<Microsoft.Extensions.Options.IOptions<Mt5ManagerOptions>>().Value);
+builder.Services.AddSingleton<Mt5ManagerClient>();
 builder.Services.AddHostedService<Worker>();
 
 var host = builder.Build();

--- a/OTS.Solution/OTS.WorkflowService/Worker.cs
+++ b/OTS.Solution/OTS.WorkflowService/Worker.cs
@@ -1,8 +1,34 @@
 using Microsoft.Extensions.Options;
 
-namespace OTS.WorkflowService
-{
-    public class Worker : BackgroundService
+        private readonly Mt5ManagerClient _mt5ManagerClient;
+        private readonly Mt5ManagerOptions _options;
+        public Worker(ILogger<Worker> logger, Mt5ManagerClient mt5ManagerClient, IOptions<Mt5ManagerOptions> options)
+            _mt5ManagerClient = mt5ManagerClient;
+            _options = options.Value;
+
+                try
+                {
+                    var snapshot = _mt5ManagerClient.GetTradeAndOrderSnapshot();
+                    _logger.LogInformation(
+                        "MT5 snapshot received from {Server}: {OrderCount} order rows and {TradeCount} trade rows.",
+                        _options.Server,
+                        snapshot.Orders.Count,
+                        snapshot.Deals.Count);
+
+                    foreach (var order in snapshot.Orders.Take(_options.PreviewCount > int.MaxValue ? int.MaxValue : (int)_options.PreviewCount))
+                    {
+                        _logger.LogInformation("MT5 order: {Order}", order);
+                    }
+
+                    foreach (var trade in snapshot.Deals.Take(_options.PreviewCount > int.MaxValue ? int.MaxValue : (int)_options.PreviewCount))
+                    {
+                        _logger.LogInformation("MT5 deal: {Trade}", trade);
+                    }
+                }
+                catch (Exception ex)
+                    _logger.LogError(ex, "Unable to get MT5 trade/order snapshot from {Server}.", _options.Server);
+
+                await Task.Delay(TimeSpan.FromSeconds(Math.Max(1, _options.PollIntervalSeconds)), stoppingToken);
     {
         private readonly ILogger<Worker> _logger;
         private readonly Mt5ManagerClient _mt5ManagerClient;

--- a/OTS.Solution/OTS.WorkflowService/Worker.cs
+++ b/OTS.Solution/OTS.WorkflowService/Worker.cs
@@ -26,16 +26,16 @@ namespace OTS.WorkflowService
                         "MT5 snapshot received from {Server}: {OrderCount} order rows and {TradeCount} trade rows.",
                         _options.Server,
                         snapshot.Orders.Count,
-                        snapshot.Trades.Count);
+                        snapshot.Deals.Count);
 
                     foreach (var order in snapshot.Orders.Take(_options.PreviewCount > int.MaxValue ? int.MaxValue : (int)_options.PreviewCount))
                     {
                         _logger.LogInformation("MT5 order: {Order}", order);
                     }
 
-                    foreach (var trade in snapshot.Trades.Take(_options.PreviewCount > int.MaxValue ? int.MaxValue : (int)_options.PreviewCount))
+                    foreach (var trade in snapshot.Deals.Take(_options.PreviewCount > int.MaxValue ? int.MaxValue : (int)_options.PreviewCount))
                     {
-                        _logger.LogInformation("MT5 trade: {Trade}", trade);
+                        _logger.LogInformation("MT5 deal: {Trade}", trade);
                     }
                 }
                 catch (Exception ex)

--- a/OTS.Solution/OTS.WorkflowService/Worker.cs
+++ b/OTS.Solution/OTS.WorkflowService/Worker.cs
@@ -1,23 +1,49 @@
+using Microsoft.Extensions.Options;
+
 namespace OTS.WorkflowService
 {
     public class Worker : BackgroundService
     {
         private readonly ILogger<Worker> _logger;
+        private readonly Mt5ManagerClient _mt5ManagerClient;
+        private readonly Mt5ManagerOptions _options;
 
-        public Worker(ILogger<Worker> logger)
+        public Worker(ILogger<Worker> logger, Mt5ManagerClient mt5ManagerClient, IOptions<Mt5ManagerOptions> options)
         {
             _logger = logger;
+            _mt5ManagerClient = mt5ManagerClient;
+            _options = options.Value;
         }
 
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         {
             while (!stoppingToken.IsCancellationRequested)
             {
-                if (_logger.IsEnabled(LogLevel.Information))
+                try
                 {
-                    _logger.LogInformation("Worker running at: {time}", DateTimeOffset.Now);
+                    var snapshot = _mt5ManagerClient.GetTradeAndOrderSnapshot();
+                    _logger.LogInformation(
+                        "MT5 snapshot received from {Server}: {OrderCount} order rows and {TradeCount} trade rows.",
+                        _options.Server,
+                        snapshot.Orders.Count,
+                        snapshot.Trades.Count);
+
+                    foreach (var order in snapshot.Orders.Take(_options.PreviewCount > int.MaxValue ? int.MaxValue : (int)_options.PreviewCount))
+                    {
+                        _logger.LogInformation("MT5 order: {Order}", order);
+                    }
+
+                    foreach (var trade in snapshot.Trades.Take(_options.PreviewCount > int.MaxValue ? int.MaxValue : (int)_options.PreviewCount))
+                    {
+                        _logger.LogInformation("MT5 trade: {Trade}", trade);
+                    }
                 }
-                await Task.Delay(1000, stoppingToken);
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Unable to get MT5 trade/order snapshot from {Server}.", _options.Server);
+                }
+
+                await Task.Delay(TimeSpan.FromSeconds(Math.Max(1, _options.PollIntervalSeconds)), stoppingToken);
             }
         }
     }

--- a/OTS.Solution/OTS.WorkflowService/appsettings.json
+++ b/OTS.Solution/OTS.WorkflowService/appsettings.json
@@ -16,7 +16,6 @@
     "MaxRows": 100,
     "OrderGroupMask": "*",
     "DealHistoryLogin": null,
-    "DealHistoryDays": 1,
-    "NativeLibraryPath": ""
+    "DealHistoryDays": 1
   }
 }

--- a/OTS.Solution/OTS.WorkflowService/appsettings.json
+++ b/OTS.Solution/OTS.WorkflowService/appsettings.json
@@ -17,5 +17,18 @@
     "OrderGroupMask": "*",
     "DealHistoryLogin": null,
     "DealHistoryDays": 1
+  },
+  "Mt5Manager": {
+    "Server": "85.195.95.30",
+    "Login": 49630,
+    "Password": "Rto@12345",
+    "PumpingMode": 0,
+    "TimeoutMilliseconds": 60000,
+    "PollIntervalSeconds": 30,
+    "PreviewCount": 10,
+    "MaxRows": 100,
+    "OrderGroupMask": "*",
+    "DealHistoryLogin": null,
+    "DealHistoryDays": 1
   }
 }

--- a/OTS.Solution/OTS.WorkflowService/appsettings.json
+++ b/OTS.Solution/OTS.WorkflowService/appsettings.json
@@ -12,6 +12,10 @@
     "PumpingMode": 0,
     "TimeoutMilliseconds": 60000,
     "PollIntervalSeconds": 30,
-    "PreviewCount": 10
+    "PreviewCount": 10,
+    "MaxRows": 100,
+    "OrderGroupMask": "*",
+    "DealHistoryLogin": null,
+    "DealHistoryDays": 1
   }
 }

--- a/OTS.Solution/OTS.WorkflowService/appsettings.json
+++ b/OTS.Solution/OTS.WorkflowService/appsettings.json
@@ -16,6 +16,7 @@
     "MaxRows": 100,
     "OrderGroupMask": "*",
     "DealHistoryLogin": null,
-    "DealHistoryDays": 1
+    "DealHistoryDays": 1,
+    "NativeLibraryPath": ""
   }
 }

--- a/OTS.Solution/OTS.WorkflowService/appsettings.json
+++ b/OTS.Solution/OTS.WorkflowService/appsettings.json
@@ -4,5 +4,14 @@
       "Default": "Information",
       "Microsoft.Hosting.Lifetime": "Information"
     }
+  },
+  "Mt5Manager": {
+    "Server": "85.195.95.30",
+    "Login": 49630,
+    "Password": "Rto@12345",
+    "PumpingMode": 0,
+    "TimeoutMilliseconds": 60000,
+    "PollIntervalSeconds": 30,
+    "PreviewCount": 10
   }
 }


### PR DESCRIPTION
### Motivation
- Enable the workflow service to poll an MT5 Manager for live trades and orders so the system can ingest or log MT5 activity for synchronization and diagnostics.
- Provide configurable connection options and a resilient, reflection-based client to support multiple variants of the MetaQuotes MT5 Manager API.

### Description
- Add `Mt5ManagerOptions` to bind MT5 connection settings from configuration and put the supplied server/login/password into `appsettings.json` under the `Mt5Manager` section.
- Add `Mt5ManagerClient`, a reflection-driven client that locates/loads the MetaQuotes assembly, connects to the manager, and retrieves order/trade snapshots using several compatible method name/argument variants, returning JSON-serialized rows via `Mt5Snapshot`.
- Update `Worker` to depend on `Mt5ManagerClient` and poll for trade/order snapshots on the configured interval, logging snapshot counts and preview rows and handling exceptions.
- Register options and the client in `Program.cs` and set the project `PlatformTarget` to `x64` to support the 64-bit manager package referenced in the project file.

### Testing
- Attempted to run `dotnet build OTS.Solution/OTS.WorkflowService/OTS.WorkflowService.csproj`, but the build could not be executed in this environment because the `dotnet` CLI is not installed (automated build failed to run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a42b5d921b483308d9f56b29d7efacb)