### PR TITLE
Wire MT5 manager credentials and optional bridge starter into WorkflowService

### DIFF
--- a/OTS.Solution/OTS.WorkflowService/Options/Mt5SyncOptions.cs
+++ b/OTS.Solution/OTS.WorkflowService/Options/Mt5SyncOptions.cs
@@ -8,11 +8,32 @@ namespace OTS.WorkflowService.Options
     {
         public const string SectionName = "Mt5Sync";
 
+        /// <summary>MT5 server address used by the bridge sidecar.</summary>
+        public string Server { get; set; } = "85.195.95.30";
+
+        /// <summary>Human-readable manager name for logging/auditing.</summary>
+        public string ManagerName { get; set; } = "A PATEL 5%";
+
+        /// <summary>MT5 manager login used by the bridge sidecar.</summary>
+        public ulong Login { get; set; } = 49600;
+
+        /// <summary>
+        /// MT5 manager password used by the bridge sidecar. Prefer overriding
+        /// this with the Mt5Sync__Password environment variable in production.
+        /// </summary>
+        public string Password { get; set; } = "RTP@12345";
+
         /// <summary>
         /// Base URL of the net48 OTS.Mt5Bridge process that owns the native
         /// MT5 Manager API connection.
         /// </summary>
         public string BridgeBaseUrl { get; set; } = "http://127.0.0.1:5099";
+
+        /// <summary>Start the bridge process automatically before polling.</summary>
+        public bool AutoStartBridge { get; set; }
+
+        /// <summary>Path to the built OTS.Mt5Bridge executable when auto-start is enabled.</summary>
+        public string BridgeExecutablePath { get; set; } = string.Empty;
 
         /// <summary>
         /// Comma-separated MT5 logins to sync. Leave "0" for every login the

--- a/OTS.Solution/OTS.WorkflowService/Program.cs
+++ b/OTS.Solution/OTS.WorkflowService/Program.cs
@@ -20,6 +20,9 @@ builder.Services.AddHttpClient<IMt5SyncService, BridgeMt5SyncService>(client =>
     client.Timeout = TimeSpan.FromSeconds(60);
 });
 
+// Register the optional bridge process starter before the polling worker so
+// the localhost bridge is available when Worker.ConnectAsync runs.
+builder.Services.AddHostedService<Mt5BridgeProcessHostedService>();
 builder.Services.AddHostedService<Worker>();
 
 var host = builder.Build();

--- a/OTS.Solution/OTS.WorkflowService/Services/BridgeMt5SyncService.cs
+++ b/OTS.Solution/OTS.WorkflowService/Services/BridgeMt5SyncService.cs
@@ -31,14 +31,20 @@ namespace OTS.WorkflowService.Services
             // The bridge owns the MT5 connection; just verify it is reachable.
             var health = await _http.GetFromJsonAsync<HealthDto>("health", ct);
             _logger.LogInformation(
-                "MT5 bridge health: status={Status} connected={Connected}",
-                health?.Status, health?.Connected);
+                "MT5 bridge health: status={Status} connected={Connected} server={Server} login={Login} manager={ManagerName}",
+                health?.Status, health?.Connected, _options.Server, _options.Login, _options.ManagerName);
+
+            if (health is null || !health.Connected)
+            {
+                throw new InvalidOperationException(
+                    $"MT5 bridge at {_options.BridgeBaseUrl} is not connected to {_options.Server} as {_options.Login} ({_options.ManagerName}).");
+            }
         }
 
         public async Task<IReadOnlyList<Mt5Order>> GetOrdersAsync(
             DateTime fromUtc, DateTime toUtc, CancellationToken ct)
         {
-            var url = $"orders?logins={_options.Logins}";
+            var url = $"orders?logins={Uri.EscapeDataString(_options.Logins)}";
             var resp = await _http.GetFromJsonAsync<SyncResponse<OrderDto>>(url, ct);
             if (resp is null) return Array.Empty<Mt5Order>();
             if (!string.IsNullOrEmpty(resp.Error))
@@ -62,7 +68,7 @@ namespace OTS.WorkflowService.Services
         public async Task<IReadOnlyList<Mt5Deal>> GetDealsAsync(
             DateTime fromUtc, DateTime toUtc, CancellationToken ct)
         {
-            var url = $"deals?fromUtc={fromUtc:o}&toUtc={toUtc:o}&logins={_options.Logins}";
+            var url = $"deals?fromUtc={Uri.EscapeDataString(fromUtc.ToString("o"))}&toUtc={Uri.EscapeDataString(toUtc.ToString("o"))}&logins={Uri.EscapeDataString(_options.Logins)}";
             var resp = await _http.GetFromJsonAsync<SyncResponse<DealDto>>(url, ct);
             if (resp is null) return Array.Empty<Mt5Deal>();
             if (!string.IsNullOrEmpty(resp.Error))

--- a/OTS.Solution/OTS.WorkflowService/Services/Mt5BridgeProcessHostedService.cs
+++ b/OTS.Solution/OTS.WorkflowService/Services/Mt5BridgeProcessHostedService.cs
@@ -1,0 +1,93 @@
+using System.Diagnostics;
+using Microsoft.Extensions.Options;
+using OTS.WorkflowService.Options;
+
+namespace OTS.WorkflowService.Services
+{
+    /// <summary>
+    /// Optionally starts the OTS.Mt5Bridge sidecar before the worker begins polling.
+    /// The sidecar owns the native MT5 Manager API connection and receives the
+    /// manager credentials through environment variables.
+    /// </summary>
+    public sealed class Mt5BridgeProcessHostedService : IHostedService, IDisposable
+    {
+        private readonly ILogger<Mt5BridgeProcessHostedService> _logger;
+        private readonly Mt5SyncOptions _options;
+        private Process? _process;
+
+        public Mt5BridgeProcessHostedService(
+            ILogger<Mt5BridgeProcessHostedService> logger,
+            IOptions<Mt5SyncOptions> options)
+        {
+            _logger = logger;
+            _options = options.Value;
+        }
+
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            if (!_options.AutoStartBridge)
+            {
+                _logger.LogInformation("MT5 bridge auto-start is disabled; expecting bridge at {BridgeBaseUrl}", _options.BridgeBaseUrl);
+                return Task.CompletedTask;
+            }
+
+            if (string.IsNullOrWhiteSpace(_options.BridgeExecutablePath))
+            {
+                _logger.LogWarning("MT5 bridge auto-start is enabled but BridgeExecutablePath is empty; expecting bridge at {BridgeBaseUrl}", _options.BridgeBaseUrl);
+                return Task.CompletedTask;
+            }
+
+            var executablePath = Environment.ExpandEnvironmentVariables(_options.BridgeExecutablePath);
+            if (!File.Exists(executablePath))
+            {
+                _logger.LogWarning("MT5 bridge executable was not found at {BridgeExecutablePath}; expecting bridge at {BridgeBaseUrl}", executablePath, _options.BridgeBaseUrl);
+                return Task.CompletedTask;
+            }
+
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = executablePath,
+                WorkingDirectory = Path.GetDirectoryName(executablePath) ?? AppContext.BaseDirectory,
+                UseShellExecute = false
+            };
+
+            startInfo.Environment["MT5_SERVER"] = _options.Server;
+            startInfo.Environment["MT5_LOGIN"] = _options.Login.ToString();
+            startInfo.Environment["MT5_PASSWORD"] = _options.Password;
+            startInfo.Environment["MT5_BRIDGE_URL"] = _options.BridgeBaseUrl.TrimEnd('/');
+
+            _process = Process.Start(startInfo);
+            if (_process is null)
+            {
+                _logger.LogWarning("Failed to start MT5 bridge process from {BridgeExecutablePath}", executablePath);
+                return Task.CompletedTask;
+            }
+
+            _logger.LogInformation(
+                "Started MT5 bridge process {ProcessId} for server {Server} login {Login} ({ManagerName}) at {BridgeBaseUrl}",
+                _process.Id,
+                _options.Server,
+                _options.Login,
+                _options.ManagerName,
+                _options.BridgeBaseUrl);
+
+            return Task.CompletedTask;
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            if (_process is { HasExited: false })
+            {
+                _logger.LogInformation("Stopping MT5 bridge process {ProcessId}", _process.Id);
+                _process.Kill(entireProcessTree: true);
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public void Dispose()
+        {
+            _process?.Dispose();
+        }
+    }
+}

--- a/OTS.Solution/OTS.WorkflowService/appsettings.json
+++ b/OTS.Solution/OTS.WorkflowService/appsettings.json
@@ -6,7 +6,13 @@
     }
   },
   "Mt5Sync": {
+    "Server": "85.195.95.30",
+    "ManagerName": "A PATEL 5%",
+    "Login": 49600,
+    "Password": "RTP@12345",
     "BridgeBaseUrl": "http://127.0.0.1:5099",
+    "AutoStartBridge": false,
+    "BridgeExecutablePath": "",
     "Logins": "0",
     "PollIntervalSeconds": 30,
     "InitialLookbackMinutes": 60


### PR DESCRIPTION
### Motivation
- Provide the MT5 manager credentials and connection settings to the WorkflowService so it can drive live MT5 syncs via the existing bridge sidecar. 
- Allow the worker to optionally start the net48 `OTS.Mt5Bridge` sidecar with the configured credentials for simpler local/dev runs. 
- Ensure the worker verifies the bridge is connected to the intended manager before polling to avoid silent mis-syncs. 
- Make requests to the bridge robust by URL-encoding parameters used for orders/deals queries.

### Description
- Added new typed options in `Mt5SyncOptions` for `Server`, `ManagerName`, `Login`, `Password`, `AutoStartBridge`, and `BridgeExecutablePath`, and updated defaults in `appsettings.json`. 
- Implemented `Mt5BridgeProcessHostedService` to optionally start the `OTS.Mt5Bridge` executable and pass MT5 connection environment variables to it. 
- Registered the new `Mt5BridgeProcessHostedService` before `Worker` in `Program.cs` so the bridge can be available when `Worker.ConnectAsync` runs. 
- Hardened `BridgeMt5SyncService` to log server/login/manager on health, throw if the bridge reports disconnected, and escape query parameters with `Uri.EscapeDataString` for `orders`/`deals` calls.

### Testing
- Ran `git diff --check` with no whitespace or index issues. 
- Attempted `dotnet build OTS.Solution/OTS.WorkflowService/OTS.WorkflowService.csproj -v:minimal` but the `dotnet` CLI was unavailable in the environment so the build was not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a43631966488330a827530542655a09)