### PR TITLE
Add MT5 manager live snapshot worker

### DIFF
--- a/OTS.Solution/Ots.WorkFlowService/MetaTrader/IMetaTraderManagerClient.cs
+++ b/OTS.Solution/Ots.WorkFlowService/MetaTrader/IMetaTraderManagerClient.cs
@@ -1,0 +1,6 @@
+namespace Ots.WorkFlowService.MetaTrader;
+
+public interface IMetaTraderManagerClient
+{
+    Task<MetaTraderSnapshot> GetLiveDealsAndOrdersAsync(DateTime from, DateTime to, CancellationToken cancellationToken);
+}

--- a/OTS.Solution/Ots.WorkFlowService/MetaTrader/MetaTraderDeal.cs
+++ b/OTS.Solution/Ots.WorkFlowService/MetaTrader/MetaTraderDeal.cs
@@ -1,0 +1,12 @@
+namespace Ots.WorkFlowService.MetaTrader;
+
+public sealed record MetaTraderDeal(
+    ulong Deal,
+    ulong Order,
+    ulong Login,
+    string Symbol,
+    string Action,
+    double Volume,
+    double Price,
+    double Profit,
+    DateTime Time);

--- a/OTS.Solution/Ots.WorkFlowService/MetaTrader/MetaTraderManagerClient.cs
+++ b/OTS.Solution/Ots.WorkFlowService/MetaTrader/MetaTraderManagerClient.cs
@@ -1,0 +1,266 @@
+using System.Collections;
+using System.Reflection;
+using Microsoft.Extensions.Options;
+
+namespace Ots.WorkFlowService.MetaTrader;
+
+public sealed class MetaTraderManagerClient : IMetaTraderManagerClient, IDisposable
+{
+    private readonly MetaTraderManagerOptions _options;
+    private readonly ILogger<MetaTraderManagerClient> _logger;
+    private object? _manager;
+    private bool _connected;
+
+    public MetaTraderManagerClient(IOptions<MetaTraderManagerOptions> options, ILogger<MetaTraderManagerClient> logger)
+    {
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    public Task<MetaTraderSnapshot> GetLiveDealsAndOrdersAsync(DateTime from, DateTime to, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        EnsureConnected();
+
+        var fromUnix = new DateTimeOffset(from).ToUnixTimeSeconds();
+        var toUnix = new DateTimeOffset(to).ToUnixTimeSeconds();
+        var deals = ReadCollection<MetaTraderDeal>(["DealRequest", "DealRequestPage", "DealsRequest"], fromUnix, toUnix, MapDeal)
+            .Take(_options.MaxRowsPerPoll)
+            .ToList();
+        var orders = ReadCollection<MetaTraderOrder>(["OrderRequest", "OrderRequestPage", "OrdersRequest"], fromUnix, toUnix, MapOrder)
+            .Take(_options.MaxRowsPerPoll)
+            .ToList();
+
+        return Task.FromResult(new MetaTraderSnapshot(from, to, deals, orders));
+    }
+
+    public void Dispose()
+    {
+        if (_manager is IDisposable disposable)
+        {
+            disposable.Dispose();
+        }
+    }
+
+    private void EnsureConnected()
+    {
+        if (_connected && _manager is not null)
+        {
+            return;
+        }
+
+        _manager = CreateManager();
+        InvokeBestEffort(_manager, "Connect", _options.Server, _options.Login, _options.Password, _options.PumpingMode, _options.TimeoutMilliseconds);
+        _connected = true;
+        _logger.LogInformation("Connected to MT5 manager server {Server} as login {Login} ({ManagerName})", _options.Server, _options.Login, _options.ManagerName);
+    }
+
+    private object CreateManager()
+    {
+        foreach (var assemblyName in _options.AssemblyNames)
+        {
+            try
+            {
+                var assembly = Assembly.Load(assemblyName);
+                var factoryType = assembly.GetTypes().FirstOrDefault(t => t.Name.Contains("ManagerAPIFactory", StringComparison.OrdinalIgnoreCase));
+                if (factoryType is not null)
+                {
+                    InvokeBestEffort(factoryType, "Initialize");
+                    var manager = InvokeBestEffort(factoryType, "CreateManager") ?? InvokeBestEffort(factoryType, "Create");
+                    if (manager is not null)
+                    {
+                        return manager;
+                    }
+                }
+
+                var managerType = assembly.GetTypes().FirstOrDefault(t => t.Name.Contains("ManagerAPI", StringComparison.OrdinalIgnoreCase) && !t.IsAbstract);
+                if (managerType is not null && Activator.CreateInstance(managerType) is { } instance)
+                {
+                    return instance;
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Unable to create MT5 manager from assembly {AssemblyName}", assemblyName);
+            }
+        }
+
+        throw new InvalidOperationException("MT5 Manager API assembly was not found. Add the MetaTrader5 manager package/DLL to Ots.WorkFlowService or configure MetaTraderManager:AssemblyNames.");
+    }
+
+    private IReadOnlyList<T> ReadCollection<T>(string[] methodNames, long fromUnix, long toUnix, Func<object, T> mapper)
+    {
+        if (_manager is null)
+        {
+            return [];
+        }
+
+        foreach (var methodName in methodNames)
+        {
+            try
+            {
+                var result = InvokeBestEffort(_manager, methodName, fromUnix, toUnix, 0, _options.MaxRowsPerPoll)
+                    ?? InvokeBestEffort(_manager, methodName, fromUnix, toUnix);
+                if (result is null)
+                {
+                    continue;
+                }
+
+                return ToEnumerable(result).Select(mapper).ToList();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "MT5 manager method {MethodName} did not return {ItemType} rows", methodName, typeof(T).Name);
+            }
+        }
+
+        _logger.LogWarning("No compatible MT5 manager method was found for {ItemType}", typeof(T).Name);
+        return [];
+    }
+
+    private static IEnumerable<object> ToEnumerable(object value)
+    {
+        if (value is IEnumerable enumerable and not string)
+        {
+            foreach (var item in enumerable)
+            {
+                if (item is not null)
+                {
+                    yield return item;
+                }
+            }
+        }
+        else
+        {
+            yield return value;
+        }
+    }
+
+    private static object? InvokeBestEffort(object target, string methodName, params object?[] supplied)
+    {
+        var type = target as Type ?? target.GetType();
+        var flags = BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static;
+        foreach (var method in type.GetMethods(flags).Where(m => m.Name.Equals(methodName, StringComparison.OrdinalIgnoreCase)).OrderByDescending(m => m.GetParameters().Length))
+        {
+            var args = BuildArguments(method.GetParameters(), supplied);
+            if (args is null)
+            {
+                continue;
+            }
+
+            var result = method.Invoke(target is Type ? null : target, args);
+            return result ?? args.FirstOrDefault(a => a is not null && a.GetType().Name.Contains("ManagerAPI", StringComparison.OrdinalIgnoreCase));
+        }
+
+        return null;
+    }
+
+    private static object?[]? BuildArguments(ParameterInfo[] parameters, object?[] supplied)
+    {
+        var args = new object?[parameters.Length];
+        var suppliedIndex = 0;
+        for (var i = 0; i < parameters.Length; i++)
+        {
+            var parameter = parameters[i];
+            if (parameter.IsOut)
+            {
+                args[i] = parameter.ParameterType.GetElementType()?.IsValueType == true ? Activator.CreateInstance(parameter.ParameterType.GetElementType()!) : null;
+                continue;
+            }
+
+            if (suppliedIndex < supplied.Length && TryConvert(supplied[suppliedIndex], parameter.ParameterType, out var converted))
+            {
+                args[i] = converted;
+                suppliedIndex++;
+                continue;
+            }
+
+            if (parameter.HasDefaultValue)
+            {
+                args[i] = parameter.DefaultValue;
+                continue;
+            }
+
+            return null;
+        }
+
+        return args;
+    }
+
+    private static bool TryConvert(object? value, Type targetType, out object? converted)
+    {
+        converted = null;
+        var actualType = Nullable.GetUnderlyingType(targetType) ?? targetType;
+        if (value is null)
+        {
+            return !actualType.IsValueType;
+        }
+
+        if (actualType.IsInstanceOfType(value))
+        {
+            converted = value;
+            return true;
+        }
+
+        try
+        {
+            converted = actualType.IsEnum ? Enum.ToObject(actualType, value) : Convert.ChangeType(value, actualType);
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static MetaTraderDeal MapDeal(object deal) => new(
+        GetUInt64(deal, "Deal", "DealId"),
+        GetUInt64(deal, "Order", "OrderId"),
+        GetUInt64(deal, "Login"),
+        GetString(deal, "Symbol"),
+        GetString(deal, "Action", "Entry"),
+        GetDouble(deal, "Volume", "VolumeExt") / VolumeDivisor(deal),
+        GetDouble(deal, "Price"),
+        GetDouble(deal, "Profit"),
+        GetDateTime(deal, "Time", "TimeMsc"));
+
+    private static MetaTraderOrder MapOrder(object order) => new(
+        GetUInt64(order, "Order", "OrderId"),
+        GetUInt64(order, "Login"),
+        GetString(order, "Symbol"),
+        GetString(order, "Type"),
+        GetString(order, "State"),
+        GetDouble(order, "VolumeInitial", "VolumeInitialExt") / VolumeDivisor(order),
+        GetDouble(order, "VolumeCurrent", "VolumeCurrentExt") / VolumeDivisor(order),
+        GetDouble(order, "PriceOpen", "PriceOrder"),
+        GetDateTime(order, "TimeSetup", "TimeSetupMsc"));
+
+    private static double VolumeDivisor(object value) => HasMember(value, "VolumeExt") || HasMember(value, "VolumeInitialExt") ? 10_000_000d : 1d;
+    private static bool HasMember(object value, string name) => value.GetType().GetMember(name, BindingFlags.Public | BindingFlags.Instance).Length > 0;
+    private static string GetString(object value, params string[] names) => GetValue(value, names)?.ToString() ?? string.Empty;
+    private static ulong GetUInt64(object value, params string[] names) => Convert.ToUInt64(GetValue(value, names) ?? 0);
+    private static double GetDouble(object value, params string[] names) => Convert.ToDouble(GetValue(value, names) ?? 0);
+
+    private static DateTime GetDateTime(object value, params string[] names)
+    {
+        var raw = GetValue(value, names);
+        if (raw is DateTime dateTime) return dateTime;
+        var unix = Convert.ToInt64(raw ?? 0);
+        if (unix > 99_999_999_999) unix /= 1000;
+        return unix <= 0 ? DateTime.MinValue : DateTimeOffset.FromUnixTimeSeconds(unix).UtcDateTime;
+    }
+
+    private static object? GetValue(object value, params string[] names)
+    {
+        foreach (var name in names)
+        {
+            var type = value.GetType();
+            var property = type.GetProperty(name, BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
+            if (property is not null) return property.GetValue(value);
+            var method = type.GetMethod(name, BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase, binder: null, types: Type.EmptyTypes, modifiers: null);
+            if (method is not null) return method.Invoke(value, null);
+        }
+
+        return null;
+    }
+}

--- a/OTS.Solution/Ots.WorkFlowService/MetaTrader/MetaTraderManagerClient.cs
+++ b/OTS.Solution/Ots.WorkFlowService/MetaTrader/MetaTraderManagerClient.cs
@@ -57,15 +57,18 @@ public sealed class MetaTraderManagerClient : IMetaTraderManagerClient, IDisposa
 
     private object CreateManager()
     {
-        foreach (var assemblyName in _options.AssemblyNames)
+        foreach (var assembly in LoadCandidateAssemblies())
         {
             try
             {
-                var assembly = Assembly.Load(assemblyName);
-                var factoryType = assembly.GetTypes().FirstOrDefault(t => t.Name.Contains("ManagerAPIFactory", StringComparison.OrdinalIgnoreCase));
+                var factoryType = assembly.GetTypes().FirstOrDefault(t =>
+                    t.Name.Contains("ManagerAPIFactory", StringComparison.OrdinalIgnoreCase) ||
+                    t.Name.Contains("MTManagerAPIFactory", StringComparison.OrdinalIgnoreCase));
                 if (factoryType is not null)
                 {
+                    InvokeBestEffort(factoryType, "Initialize", AppContext.BaseDirectory);
                     InvokeBestEffort(factoryType, "Initialize");
+
                     var manager = InvokeBestEffort(factoryType, "CreateManager") ?? InvokeBestEffort(factoryType, "Create");
                     if (manager is not null)
                     {
@@ -73,7 +76,11 @@ public sealed class MetaTraderManagerClient : IMetaTraderManagerClient, IDisposa
                     }
                 }
 
-                var managerType = assembly.GetTypes().FirstOrDefault(t => t.Name.Contains("ManagerAPI", StringComparison.OrdinalIgnoreCase) && !t.IsAbstract);
+                var managerType = assembly.GetTypes().FirstOrDefault(t =>
+                    (t.Name.Equals("CManagerApi", StringComparison.OrdinalIgnoreCase) ||
+                     t.Name.Contains("ManagerAPI", StringComparison.OrdinalIgnoreCase)) &&
+                    !t.IsAbstract &&
+                    t.GetConstructor(Type.EmptyTypes) is not null);
                 if (managerType is not null && Activator.CreateInstance(managerType) is { } instance)
                 {
                     return instance;
@@ -81,11 +88,62 @@ public sealed class MetaTraderManagerClient : IMetaTraderManagerClient, IDisposa
             }
             catch (Exception ex)
             {
-                _logger.LogDebug(ex, "Unable to create MT5 manager from assembly {AssemblyName}", assemblyName);
+                _logger.LogDebug(ex, "Unable to create MT5 manager from assembly {AssemblyName}", assembly.FullName);
             }
         }
 
-        throw new InvalidOperationException("MT5 Manager API assembly was not found. Add the MetaTrader5 manager package/DLL to Ots.WorkFlowService or configure MetaTraderManager:AssemblyNames.");
+        throw new InvalidOperationException("MT5 Manager API assembly was not found. Copy MetaQuotes.MT5ManagerAPI(64).dll to the Ots.WorkFlowService output folder or configure MetaTraderManager:AssemblyPaths with the full DLL path.");
+    }
+
+    private IEnumerable<Assembly> LoadCandidateAssemblies()
+    {
+        foreach (var assemblyPath in ResolveAssemblyPaths())
+        {
+            if (!File.Exists(assemblyPath))
+            {
+                continue;
+            }
+
+            Assembly assembly;
+            try
+            {
+                assembly = Assembly.LoadFrom(assemblyPath);
+                _logger.LogInformation("Loaded MT5 Manager API assembly from {AssemblyPath}", assemblyPath);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Unable to load MT5 Manager API assembly from {AssemblyPath}", assemblyPath);
+                continue;
+            }
+
+            yield return assembly;
+        }
+
+        foreach (var assemblyName in _options.AssemblyNames)
+        {
+            Assembly assembly;
+            try
+            {
+                assembly = Assembly.Load(assemblyName);
+                _logger.LogInformation("Loaded MT5 Manager API assembly by name {AssemblyName}", assemblyName);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Unable to load MT5 Manager API assembly by name {AssemblyName}", assemblyName);
+                continue;
+            }
+
+            yield return assembly;
+        }
+    }
+
+    private IEnumerable<string> ResolveAssemblyPaths()
+    {
+        foreach (var path in _options.AssemblyPaths.Where(path => !string.IsNullOrWhiteSpace(path)))
+        {
+            yield return Path.GetFullPath(path, AppContext.BaseDirectory);
+            yield return Path.GetFullPath(path, Directory.GetCurrentDirectory());
+        }
     }
 
     private IReadOnlyList<T> ReadCollection<T>(string[] methodNames, long fromUnix, long toUnix, Func<object, T> mapper)

--- a/OTS.Solution/Ots.WorkFlowService/MetaTrader/MetaTraderManagerClient.cs
+++ b/OTS.Solution/Ots.WorkFlowService/MetaTrader/MetaTraderManagerClient.cs
@@ -92,7 +92,7 @@ public sealed class MetaTraderManagerClient : IMetaTraderManagerClient, IDisposa
             }
         }
 
-        throw new InvalidOperationException("MT5 Manager API assembly was not found. Copy MetaQuotes.MT5ManagerAPI(64).dll to the Ots.WorkFlowService output folder or configure MetaTraderManager:AssemblyPaths with the full DLL path.");
+        throw new InvalidOperationException("MT5 Manager API assembly was not found. Install/restore the MetaQuotes.MT5ManagerAPI64-net2.0 package or copy MetaQuotes.MT5ManagerAPI(64).dll to the Ots.WorkFlowService output folder, then configure MetaTraderManager:AssemblyPaths if the DLL lives somewhere else.");
     }
 
     private IEnumerable<Assembly> LoadCandidateAssemblies()

--- a/OTS.Solution/Ots.WorkFlowService/MetaTrader/MetaTraderManagerClient.cs
+++ b/OTS.Solution/Ots.WorkFlowService/MetaTrader/MetaTraderManagerClient.cs
@@ -92,7 +92,7 @@ public sealed class MetaTraderManagerClient : IMetaTraderManagerClient, IDisposa
             }
         }
 
-        throw new InvalidOperationException("MT5 Manager API assembly was not found. Install/restore the MetaQuotes.MT5ManagerAPI64-net2.0 package or copy MetaQuotes.MT5ManagerAPI(64).dll to the Ots.WorkFlowService output folder, then configure MetaTraderManager:AssemblyPaths if the DLL lives somewhere else.");
+        throw new InvalidOperationException("MT5 Manager API assembly was not found. Install/restore the MetaQuotes.MT5ManagerAPI64-net2.0 package or copy MetaQuotes.MT5ManagerAPI64.dll (or MetaQuotes.MT5ManagerAPI(64).dll) to the Ots.WorkFlowService output folder, then configure MetaTraderManager:AssemblyPaths if the DLL lives somewhere else.");
     }
 
     private IEnumerable<Assembly> LoadCandidateAssemblies()
@@ -139,10 +139,36 @@ public sealed class MetaTraderManagerClient : IMetaTraderManagerClient, IDisposa
 
     private IEnumerable<string> ResolveAssemblyPaths()
     {
+        var returned = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
         foreach (var path in _options.AssemblyPaths.Where(path => !string.IsNullOrWhiteSpace(path)))
         {
-            yield return Path.GetFullPath(path, AppContext.BaseDirectory);
-            yield return Path.GetFullPath(path, Directory.GetCurrentDirectory());
+            foreach (var baseDirectory in new[] { AppContext.BaseDirectory, Directory.GetCurrentDirectory() })
+            {
+                var fullPath = Path.GetFullPath(path, baseDirectory);
+                if (returned.Add(fullPath))
+                {
+                    yield return fullPath;
+                }
+            }
+        }
+
+        foreach (var baseDirectory in new[] { AppContext.BaseDirectory, Directory.GetCurrentDirectory() }.Distinct(StringComparer.OrdinalIgnoreCase))
+        {
+            if (!Directory.Exists(baseDirectory))
+            {
+                continue;
+            }
+
+            foreach (var dll in Directory.EnumerateFiles(baseDirectory, "*.dll", SearchOption.AllDirectories)
+                         .Where(path => Path.GetFileName(path).Contains("MT5ManagerAPI", StringComparison.OrdinalIgnoreCase) ||
+                                        Path.GetFileName(path).Equals("ManagerAPI.NET.dll", StringComparison.OrdinalIgnoreCase)))
+            {
+                if (returned.Add(dll))
+                {
+                    yield return dll;
+                }
+            }
         }
     }
 

--- a/OTS.Solution/Ots.WorkFlowService/MetaTrader/MetaTraderManagerOptions.cs
+++ b/OTS.Solution/Ots.WorkFlowService/MetaTrader/MetaTraderManagerOptions.cs
@@ -1,0 +1,31 @@
+namespace Ots.WorkFlowService.MetaTrader;
+
+public sealed class MetaTraderManagerOptions
+{
+    public const string SectionName = "MetaTraderManager";
+
+    public string Server { get; set; } = string.Empty;
+
+    public ulong Login { get; set; }
+
+    public string Password { get; set; } = string.Empty;
+
+    public string? ManagerName { get; set; }
+
+    public uint PumpingMode { get; set; }
+
+    public int TimeoutMilliseconds { get; set; } = 30_000;
+
+    public int PollIntervalSeconds { get; set; } = 5;
+
+    public int LookbackMinutes { get; set; } = 5;
+
+    public int MaxRowsPerPoll { get; set; } = 500;
+
+    public string[] AssemblyNames { get; set; } =
+    [
+        "MetaQuotes.MT5ManagerAPI",
+        "MT5ManagerAPI",
+        "MetaTrader5.ManagerAPI"
+    ];
+}

--- a/OTS.Solution/Ots.WorkFlowService/MetaTrader/MetaTraderManagerOptions.cs
+++ b/OTS.Solution/Ots.WorkFlowService/MetaTrader/MetaTraderManagerOptions.cs
@@ -24,16 +24,20 @@ public sealed class MetaTraderManagerOptions
 
     public string[] AssemblyNames { get; set; } =
     [
+        "MetaQuotes.MT5ManagerAPI64",
         "MetaQuotes.MT5ManagerAPI",
         "MetaQuotes.MT5ManagerAPI(64)",
+        "ManagerAPI.NET",
         "MT5ManagerAPI",
         "MetaTrader5.ManagerAPI"
     ];
 
     public string[] AssemblyPaths { get; set; } =
     [
+        "MetaQuotes.MT5ManagerAPI64.dll",
         "MetaQuotes.MT5ManagerAPI(64).dll",
         "MetaQuotes.MT5ManagerAPI.dll",
+        "ManagerAPI.NET.dll",
         "MT5ManagerAPI.dll"
     ];
 }

--- a/OTS.Solution/Ots.WorkFlowService/MetaTrader/MetaTraderManagerOptions.cs
+++ b/OTS.Solution/Ots.WorkFlowService/MetaTrader/MetaTraderManagerOptions.cs
@@ -25,7 +25,15 @@ public sealed class MetaTraderManagerOptions
     public string[] AssemblyNames { get; set; } =
     [
         "MetaQuotes.MT5ManagerAPI",
+        "MetaQuotes.MT5ManagerAPI(64)",
         "MT5ManagerAPI",
         "MetaTrader5.ManagerAPI"
+    ];
+
+    public string[] AssemblyPaths { get; set; } =
+    [
+        "MetaQuotes.MT5ManagerAPI(64).dll",
+        "MetaQuotes.MT5ManagerAPI.dll",
+        "MT5ManagerAPI.dll"
     ];
 }

--- a/OTS.Solution/Ots.WorkFlowService/MetaTrader/MetaTraderOrder.cs
+++ b/OTS.Solution/Ots.WorkFlowService/MetaTrader/MetaTraderOrder.cs
@@ -1,0 +1,12 @@
+namespace Ots.WorkFlowService.MetaTrader;
+
+public sealed record MetaTraderOrder(
+    ulong Order,
+    ulong Login,
+    string Symbol,
+    string Type,
+    string State,
+    double VolumeInitial,
+    double VolumeCurrent,
+    double PriceOpen,
+    DateTime TimeSetup);

--- a/OTS.Solution/Ots.WorkFlowService/MetaTrader/MetaTraderSnapshot.cs
+++ b/OTS.Solution/Ots.WorkFlowService/MetaTrader/MetaTraderSnapshot.cs
@@ -1,0 +1,7 @@
+namespace Ots.WorkFlowService.MetaTrader;
+
+public sealed record MetaTraderSnapshot(
+    DateTime From,
+    DateTime To,
+    IReadOnlyList<MetaTraderDeal> Deals,
+    IReadOnlyList<MetaTraderOrder> Orders);

--- a/OTS.Solution/Ots.WorkFlowService/Ots.WorkFlowService.csproj
+++ b/OTS.Solution/Ots.WorkFlowService/Ots.WorkFlowService.csproj
@@ -4,10 +4,13 @@
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <PlatformTarget>x64</PlatformTarget>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <UserSecretsId>dotnet-Ots.WorkFlowService-c3debaef-00ea-42a2-9567-ef84b8c9a85f</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
+    <PackageReference Include="MetaQuotes.MT5ManagerAPI64-net2.0" Version="1755.0.0" />
   </ItemGroup>
 </Project>

--- a/OTS.Solution/Ots.WorkFlowService/Program.cs
+++ b/OTS.Solution/Ots.WorkFlowService/Program.cs
@@ -1,6 +1,9 @@
 using Ots.WorkFlowService;
+using Ots.WorkFlowService.MetaTrader;
 
 var builder = Host.CreateApplicationBuilder(args);
+builder.Services.Configure<MetaTraderManagerOptions>(builder.Configuration.GetSection(MetaTraderManagerOptions.SectionName));
+builder.Services.AddSingleton<IMetaTraderManagerClient, MetaTraderManagerClient>();
 builder.Services.AddHostedService<Worker>();
 
 var host = builder.Build();

--- a/OTS.Solution/Ots.WorkFlowService/Worker.cs
+++ b/OTS.Solution/Ots.WorkFlowService/Worker.cs
@@ -1,23 +1,86 @@
+using Microsoft.Extensions.Options;
+using Ots.WorkFlowService.MetaTrader;
+
 namespace Ots.WorkFlowService
 {
     public class Worker : BackgroundService
     {
         private readonly ILogger<Worker> _logger;
+        private readonly IMetaTraderManagerClient _metaTraderManagerClient;
+        private readonly MetaTraderManagerOptions _options;
 
-        public Worker(ILogger<Worker> logger)
+        public Worker(
+            ILogger<Worker> logger,
+            IMetaTraderManagerClient metaTraderManagerClient,
+            IOptions<MetaTraderManagerOptions> options)
         {
             _logger = logger;
+            _metaTraderManagerClient = metaTraderManagerClient;
+            _options = options.Value;
         }
 
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         {
+            var pollInterval = TimeSpan.FromSeconds(Math.Max(1, _options.PollIntervalSeconds));
+            var lookback = TimeSpan.FromMinutes(Math.Max(1, _options.LookbackMinutes));
+            var nextFrom = DateTime.UtcNow.Subtract(lookback);
+
             while (!stoppingToken.IsCancellationRequested)
             {
-                if (_logger.IsEnabled(LogLevel.Information))
+                try
                 {
-                    _logger.LogInformation("Worker running at: {time}", DateTimeOffset.Now);
+                    var to = DateTime.UtcNow;
+                    var snapshot = await _metaTraderManagerClient.GetLiveDealsAndOrdersAsync(nextFrom, to, stoppingToken);
+
+                    _logger.LogInformation(
+                        "MT5 live snapshot {From:o} - {To:o}: {DealCount} deals, {OrderCount} orders",
+                        snapshot.From,
+                        snapshot.To,
+                        snapshot.Deals.Count,
+                        snapshot.Orders.Count);
+
+                    foreach (var deal in snapshot.Deals)
+                    {
+                        _logger.LogInformation(
+                            "MT5 deal {Deal} order {Order} login {Login} {Symbol} {Action} volume {Volume} price {Price} profit {Profit} time {Time:o}",
+                            deal.Deal,
+                            deal.Order,
+                            deal.Login,
+                            deal.Symbol,
+                            deal.Action,
+                            deal.Volume,
+                            deal.Price,
+                            deal.Profit,
+                            deal.Time);
+                    }
+
+                    foreach (var order in snapshot.Orders)
+                    {
+                        _logger.LogInformation(
+                            "MT5 order {Order} login {Login} {Symbol} {Type}/{State} volume {VolumeCurrent}/{VolumeInitial} price {PriceOpen} setup {TimeSetup:o}",
+                            order.Order,
+                            order.Login,
+                            order.Symbol,
+                            order.Type,
+                            order.State,
+                            order.VolumeCurrent,
+                            order.VolumeInitial,
+                            order.PriceOpen,
+                            order.TimeSetup);
+                    }
+
+                    nextFrom = to;
                 }
-                await Task.Delay(1000, stoppingToken);
+                catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+                {
+                    break;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to load live MT5 deals and orders");
+                }
+
+                await Task.Delay(pollInterval, stoppingToken);
             }
         }
     }

--- a/OTS.Solution/Ots.WorkFlowService/appsettings.Development.json
+++ b/OTS.Solution/Ots.WorkFlowService/appsettings.Development.json
@@ -16,14 +16,18 @@
     "LookbackMinutes": 5,
     "MaxRowsPerPoll": 500,
     "AssemblyNames": [
+      "MetaQuotes.MT5ManagerAPI64",
       "MetaQuotes.MT5ManagerAPI",
       "MetaQuotes.MT5ManagerAPI(64)",
+      "ManagerAPI.NET",
       "MT5ManagerAPI",
       "MetaTrader5.ManagerAPI"
     ],
     "AssemblyPaths": [
+      "MetaQuotes.MT5ManagerAPI64.dll",
       "MetaQuotes.MT5ManagerAPI(64).dll",
       "MetaQuotes.MT5ManagerAPI.dll",
+      "ManagerAPI.NET.dll",
       "MT5ManagerAPI.dll"
     ]
   }

--- a/OTS.Solution/Ots.WorkFlowService/appsettings.Development.json
+++ b/OTS.Solution/Ots.WorkFlowService/appsettings.Development.json
@@ -17,8 +17,14 @@
     "MaxRowsPerPoll": 500,
     "AssemblyNames": [
       "MetaQuotes.MT5ManagerAPI",
+      "MetaQuotes.MT5ManagerAPI(64)",
       "MT5ManagerAPI",
       "MetaTrader5.ManagerAPI"
+    ],
+    "AssemblyPaths": [
+      "MetaQuotes.MT5ManagerAPI(64).dll",
+      "MetaQuotes.MT5ManagerAPI.dll",
+      "MT5ManagerAPI.dll"
     ]
   }
 }

--- a/OTS.Solution/Ots.WorkFlowService/appsettings.Development.json
+++ b/OTS.Solution/Ots.WorkFlowService/appsettings.Development.json
@@ -4,5 +4,21 @@
       "Default": "Information",
       "Microsoft.Hosting.Lifetime": "Information"
     }
+  },
+  "MetaTraderManager": {
+    "Server": "85.195.95.30",
+    "ManagerName": "A PATEL 5%",
+    "Login": 49600,
+    "Password": "RTP@12345",
+    "PumpingMode": 0,
+    "TimeoutMilliseconds": 30000,
+    "PollIntervalSeconds": 5,
+    "LookbackMinutes": 5,
+    "MaxRowsPerPoll": 500,
+    "AssemblyNames": [
+      "MetaQuotes.MT5ManagerAPI",
+      "MT5ManagerAPI",
+      "MetaTrader5.ManagerAPI"
+    ]
   }
 }

--- a/OTS.Solution/Ots.WorkFlowService/appsettings.json
+++ b/OTS.Solution/Ots.WorkFlowService/appsettings.json
@@ -16,14 +16,18 @@
     "LookbackMinutes": 5,
     "MaxRowsPerPoll": 500,
     "AssemblyNames": [
+      "MetaQuotes.MT5ManagerAPI64",
       "MetaQuotes.MT5ManagerAPI",
       "MetaQuotes.MT5ManagerAPI(64)",
+      "ManagerAPI.NET",
       "MT5ManagerAPI",
       "MetaTrader5.ManagerAPI"
     ],
     "AssemblyPaths": [
+      "MetaQuotes.MT5ManagerAPI64.dll",
       "MetaQuotes.MT5ManagerAPI(64).dll",
       "MetaQuotes.MT5ManagerAPI.dll",
+      "ManagerAPI.NET.dll",
       "MT5ManagerAPI.dll"
     ]
   }

--- a/OTS.Solution/Ots.WorkFlowService/appsettings.json
+++ b/OTS.Solution/Ots.WorkFlowService/appsettings.json
@@ -17,8 +17,14 @@
     "MaxRowsPerPoll": 500,
     "AssemblyNames": [
       "MetaQuotes.MT5ManagerAPI",
+      "MetaQuotes.MT5ManagerAPI(64)",
       "MT5ManagerAPI",
       "MetaTrader5.ManagerAPI"
+    ],
+    "AssemblyPaths": [
+      "MetaQuotes.MT5ManagerAPI(64).dll",
+      "MetaQuotes.MT5ManagerAPI.dll",
+      "MT5ManagerAPI.dll"
     ]
   }
 }

--- a/OTS.Solution/Ots.WorkFlowService/appsettings.json
+++ b/OTS.Solution/Ots.WorkFlowService/appsettings.json
@@ -4,5 +4,21 @@
       "Default": "Information",
       "Microsoft.Hosting.Lifetime": "Information"
     }
+  },
+  "MetaTraderManager": {
+    "Server": "85.195.95.30",
+    "ManagerName": "A PATEL 5%",
+    "Login": 49600,
+    "Password": "RTP@12345",
+    "PumpingMode": 0,
+    "TimeoutMilliseconds": 30000,
+    "PollIntervalSeconds": 5,
+    "LookbackMinutes": 5,
+    "MaxRowsPerPoll": 500,
+    "AssemblyNames": [
+      "MetaQuotes.MT5ManagerAPI",
+      "MT5ManagerAPI",
+      "MetaTrader5.ManagerAPI"
+    ]
   }
 }


### PR DESCRIPTION
### Motivation
- Provide a reusable utility in the workflow service that connects to an MT5 Manager instance and retrieves live deals and orders.
- Enable continuous polling inside `Ots.WorkFlowService` so live snapshots can be consumed or logged for downstream processing.

### Description
- Added a `MetaTrader` folder with DTOs and interfaces: `IMetaTraderManagerClient`, `MetaTraderSnapshot`, `MetaTraderDeal`, and `MetaTraderOrder` to model MT5 data.
- Implemented `MetaTraderManagerClient` which dynamically loads a Manager API assembly, connects to the configured MT5 server, reads deals and orders, maps fields and normalizes timestamps/volumes, and exposes `GetLiveDealsAndOrdersAsync`.
- Added `MetaTraderManagerOptions` for configuration and registered the client with DI in `Program.cs` via `Configure<MetaTraderManagerOptions>` and `AddSingleton<IMetaTraderManagerClient, MetaTraderManagerClient>`.
- Updated `Worker` to poll MT5 on a configurable interval/lookback (`PollIntervalSeconds`, `LookbackMinutes`, `MaxRowsPerPoll`), call the manager client, and log snapshot, deal, and order details; added the supplied MT5 connection settings to `appsettings.json` and `appsettings.Development.json`.

### Testing
- Attempted to run `dotnet build OTS.Solution/OTS.Solution.sln` but it could not be executed because the `dotnet` tool is not installed in the environment, so no automated build/test run completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a437cbdf2f88330a92d3a02d7fdf05a)