### PR TITLE
Add MT5 manager sync utility

### DIFF
--- a/OTS.Solution/Ots.WorkFlowService/Mt5ManagerOptions.cs
+++ b/OTS.Solution/Ots.WorkFlowService/Mt5ManagerOptions.cs
@@ -1,0 +1,18 @@
+namespace Ots.WorkFlowService;
+
+public sealed class Mt5ManagerOptions
+{
+    public const string SectionName = "Mt5Manager";
+
+    public ulong Login { get; set; } = 49600;
+
+    public string Password { get; set; } = string.Empty;
+
+    public string Server { get; set; } = "85.195.95.30";
+
+    public int Port { get; set; } = 443;
+
+    public string ManagerName { get; set; } = "A PATEL 5%";
+
+    public int DealHistoryLookbackDays { get; set; } = 1;
+}

--- a/OTS.Solution/Ots.WorkFlowService/Mt5ManagerSnapshot.cs
+++ b/OTS.Solution/Ots.WorkFlowService/Mt5ManagerSnapshot.cs
@@ -1,0 +1,9 @@
+using mtapi.mt5;
+
+namespace Ots.WorkFlowService;
+
+public sealed record Mt5ManagerSnapshot(
+    IReadOnlyCollection<Order> OpenedOrders,
+    IReadOnlyCollection<Order> DealHistoryOrders,
+    IReadOnlyCollection<object> InternalDeals,
+    IReadOnlyCollection<object> InternalOrders);

--- a/OTS.Solution/Ots.WorkFlowService/Mt5ManagerUtility.cs
+++ b/OTS.Solution/Ots.WorkFlowService/Mt5ManagerUtility.cs
@@ -1,0 +1,76 @@
+using Microsoft.Extensions.Options;
+using mtapi.mt5;
+
+namespace Ots.WorkFlowService;
+
+public sealed class Mt5ManagerUtility
+{
+    private readonly Mt5ManagerOptions _options;
+    private readonly ILogger<Mt5ManagerUtility> _logger;
+
+    public Mt5ManagerUtility(IOptions<Mt5ManagerOptions> options, ILogger<Mt5ManagerUtility> logger)
+    {
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    public Task<Mt5ManagerSnapshot> GetDealsAndOrdersAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (string.IsNullOrWhiteSpace(_options.Password))
+        {
+            throw new InvalidOperationException("MT5 manager password is not configured. Set Mt5Manager:Password or the Mt5Manager__Password environment variable.");
+        }
+
+        var api = new MT5API(_options.Login, _options.Password, _options.Server, _options.Port);
+
+        try
+        {
+            _logger.LogInformation(
+                "Connecting to MT5 manager {ManagerName} ({Login}) at {Server}:{Port}.",
+                _options.ManagerName,
+                _options.Login,
+                _options.Server,
+                _options.Port);
+
+            api.Connect();
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var openedOrders = api.GetOpenedOrders() ?? Array.Empty<Order>();
+            var to = DateTime.UtcNow;
+            var from = to.AddDays(-Math.Max(1, _options.DealHistoryLookbackDays));
+            var history = api.DownloadOrderHistory(from, to);
+
+            var dealHistoryOrders = history?.Orders ?? Array.Empty<Order>();
+            var internalDeals = ToObjectArray(history?.InternalDeals);
+            var internalOrders = ToObjectArray(history?.InternalOrders);
+
+            _logger.LogInformation(
+                "MT5 sync completed. OpenOrders={OpenOrderCount}, HistoryOrders={HistoryOrderCount}, InternalDeals={InternalDealCount}, InternalOrders={InternalOrderCount}.",
+                openedOrders.Length,
+                dealHistoryOrders.Count,
+                internalDeals.Count,
+                internalOrders.Count);
+
+            return Task.FromResult(new Mt5ManagerSnapshot(openedOrders, dealHistoryOrders, internalDeals, internalOrders));
+        }
+        finally
+        {
+            if (api.Connected)
+            {
+                api.Disconnect();
+            }
+        }
+    }
+
+    private static IReadOnlyCollection<object> ToObjectArray(System.Collections.IEnumerable? values)
+    {
+        if (values is null)
+        {
+            return Array.Empty<object>();
+        }
+
+        return values.Cast<object>().ToArray();
+    }
+}

--- a/OTS.Solution/Ots.WorkFlowService/Program.cs
+++ b/OTS.Solution/Ots.WorkFlowService/Program.cs
@@ -1,6 +1,9 @@
 using Ots.WorkFlowService;
 
 var builder = Host.CreateApplicationBuilder(args);
+builder.Services.Configure<Mt5ManagerOptions>(
+    builder.Configuration.GetSection(Mt5ManagerOptions.SectionName));
+builder.Services.AddSingleton<Mt5ManagerUtility>();
 builder.Services.AddHostedService<Worker>();
 
 var host = builder.Build();

--- a/OTS.Solution/Ots.WorkFlowService/Worker.cs
+++ b/OTS.Solution/Ots.WorkFlowService/Worker.cs
@@ -1,24 +1,60 @@
+using Microsoft.Extensions.Options;
+using mtapi.mt5;
+
 namespace Ots.WorkFlowService
 {
     public class Worker : BackgroundService
     {
         private readonly ILogger<Worker> _logger;
+        private readonly Mt5ManagerUtility _mt5ManagerUtility;
+        private readonly Mt5ManagerOptions _options;
 
-        public Worker(ILogger<Worker> logger)
+        public Worker(
+            ILogger<Worker> logger,
+            Mt5ManagerUtility mt5ManagerUtility,
+            IOptions<Mt5ManagerOptions> options)
         {
             _logger = logger;
+            _mt5ManagerUtility = mt5ManagerUtility;
+            _options = options.Value;
         }
 
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         {
-            while (!stoppingToken.IsCancellationRequested)
+            var snapshot = await _mt5ManagerUtility.GetDealsAndOrdersAsync(stoppingToken);
+
+            foreach (var order in snapshot.OpenedOrders)
             {
-                if (_logger.IsEnabled(LogLevel.Information))
-                {
-                    _logger.LogInformation("Worker running at: {time}", DateTimeOffset.Now);
-                }
-                await Task.Delay(1000, stoppingToken);
+                LogOrder("Open order", order);
             }
+
+            foreach (var dealOrder in snapshot.DealHistoryOrders)
+            {
+                LogOrder("Deal/history order", dealOrder);
+            }
+
+            _logger.LogInformation(
+                "MT5 manager snapshot for {ManagerName} ({Login}) contains {OpenOrderCount} open orders, {HistoryOrderCount} deal/history orders and {InternalDealCount} internal deals.",
+                _options.ManagerName,
+                _options.Login,
+                snapshot.OpenedOrders.Count,
+                snapshot.DealHistoryOrders.Count,
+                snapshot.InternalDeals.Count);
+        }
+
+        private void LogOrder(string label, Order order)
+        {
+            _logger.LogInformation(
+                "{Label}: Ticket={Ticket}, Lots={Lots}, Symbol={Symbol}, Type={OrderType}, OpenPrice={OpenPrice}, OpenTime={OpenTime}, CloseTime={CloseTime}, Profit={Profit}.",
+                label,
+                order.Ticket,
+                order.Lots,
+                order.Symbol,
+                order.OrderType,
+                order.OpenPrice,
+                order.OpenTime,
+                order.CloseTime,
+                order.Profit);
         }
     }
 }

--- a/OTS.Solution/Ots.WorkFlowService/appsettings.Development.json
+++ b/OTS.Solution/Ots.WorkFlowService/appsettings.Development.json
@@ -4,5 +4,13 @@
       "Default": "Information",
       "Microsoft.Hosting.Lifetime": "Information"
     }
+  },
+  "Mt5Manager": {
+    "Server": "85.195.95.30",
+    "Port": 443,
+    "Login": 49600,
+    "Password": "",
+    "ManagerName": "A PATEL 5%",
+    "DealHistoryLookbackDays": 1
   }
 }

--- a/OTS.Solution/Ots.WorkFlowService/appsettings.json
+++ b/OTS.Solution/Ots.WorkFlowService/appsettings.json
@@ -4,5 +4,13 @@
       "Default": "Information",
       "Microsoft.Hosting.Lifetime": "Information"
     }
+  },
+  "Mt5Manager": {
+    "Server": "85.195.95.30",
+    "Port": 443,
+    "Login": 49600,
+    "Password": "",
+    "ManagerName": "A PATEL 5%",
+    "DealHistoryLookbackDays": 1
   }
 }


### PR DESCRIPTION
### Motivation
- Provide a reusable, configuration-driven utility in the workflow service that connects to an MT5 manager, retrieves open orders and recent order/deal history, and exposes a snapshot for downstream processing and logging.
- Keep credentials and behavior configurable while avoiding checked-in secrets by leaving the password blank in source config and requiring it from `Mt5Manager:Password` or the `Mt5Manager__Password` environment variable.

### Description
- Added `Mt5ManagerOptions` with configuration keys for `Server`, `Port`, `Login`, `Password`, `ManagerName`, and `DealHistoryLookbackDays` and wired it into `Program.cs` via `builder.Services.Configure(...)`.
- Implemented `Mt5ManagerUtility` which uses `MT5API` to `Connect()`, call `GetOpenedOrders()` and `DownloadOrderHistory(from,to)`, convert internal collections to object arrays, log counts, and always `Disconnect()` in a `finally` block.
- Added `Mt5ManagerSnapshot` record to return `OpenedOrders`, `DealHistoryOrders`, `InternalDeals`, and `InternalOrders` from the utility.
- Updated `Worker` to call the utility once at startup, log each open/deal order with detailed fields, and log summary counts; updated `appsettings.json` and `appsettings.Development.json` to include an empty `Mt5Manager` section (password intentionally blank).

### Testing
- Attempted to run `dotnet build OTS.Solution/Ots.WorkFlowService/Ots.WorkFlowService.csproj`, but `dotnet` is not available in this environment so the build could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a440f1b5a9c8330893e01549da42c84)