### PR TITLE
Add MT5 manager deal and order sync utility

### DIFF
--- a/OTS.Solution/Ots.WorkFlowService/MetaTrader/IMetaTraderManagerClient.cs
+++ b/OTS.Solution/Ots.WorkFlowService/MetaTrader/IMetaTraderManagerClient.cs
@@ -1,0 +1,10 @@
+namespace Ots.WorkFlowService.MetaTrader;
+
+public interface IMetaTraderManagerClient
+{
+    Task<MetaTraderSnapshot> GetDealsAndOrdersAsync(
+        DateTime fromUtc,
+        DateTime toUtc,
+        ulong tradingLogin,
+        CancellationToken cancellationToken = default);
+}

--- a/OTS.Solution/Ots.WorkFlowService/MetaTrader/IMetaTraderManagerClient.cs
+++ b/OTS.Solution/Ots.WorkFlowService/MetaTrader/IMetaTraderManagerClient.cs
@@ -2,6 +2,8 @@ namespace Ots.WorkFlowService.MetaTrader;
 
 public interface IMetaTraderManagerClient
 {
+    Task<bool> CheckLoginAsync(CancellationToken cancellationToken = default);
+
     Task<MetaTraderSnapshot> GetDealsAndOrdersAsync(
         DateTime fromUtc,
         DateTime toUtc,

--- a/OTS.Solution/Ots.WorkFlowService/MetaTrader/MetaTraderManagerClient.cs
+++ b/OTS.Solution/Ots.WorkFlowService/MetaTrader/MetaTraderManagerClient.cs
@@ -133,7 +133,47 @@ public sealed class MetaTraderManagerClient : IMetaTraderManagerClient
 
     private void Login(object manager)
     {
-        Invoke(manager, "Login", _options.Server, _options.ManagerLogin, _options.Password);
+        if (!TryInvoke(
+                manager,
+                "Login",
+                out var loginResult,
+                _options.Server,
+                _options.ManagerLogin,
+                _options.Password,
+                _options.ConnectionTimeoutMilliseconds)
+            && !TryInvoke(
+                manager,
+                "Login",
+                out loginResult,
+                _options.Server,
+                _options.ManagerLogin,
+                _options.Password)
+            && !TryInvoke(
+                manager,
+                "Connect",
+                out loginResult,
+                _options.Server,
+                _options.ManagerLogin,
+                _options.Password,
+                _options.ConnectionTimeoutMilliseconds)
+            && !TryInvoke(
+                manager,
+                "Connect",
+                out loginResult,
+                _options.Server,
+                _options.ManagerLogin,
+                _options.Password,
+                0,
+                _options.ConnectionTimeoutMilliseconds))
+        {
+            throw CreateMissingMethodException(manager, "Login", "Connect");
+        }
+
+        if (loginResult is bool isConnected && !isConnected)
+        {
+            throw new InvalidOperationException(
+                $"MT5 manager login returned false for manager {_options.ManagerLogin} on {_options.Server}.");
+        }
 
         _logger.LogInformation(
             "Connected to MT5 manager {ManagerName} ({ManagerLogin}) on {Server}.",
@@ -144,18 +184,60 @@ public sealed class MetaTraderManagerClient : IMetaTraderManagerClient
 
     private static object? Invoke(object target, string methodName, params object[] arguments)
     {
-        var method = target.GetType()
-            .GetMethods(BindingFlags.Instance | BindingFlags.Public)
-            .Where(candidate => string.Equals(candidate.Name, methodName, StringComparison.Ordinal))
-            .FirstOrDefault(candidate => ParametersMatch(candidate.GetParameters(), arguments));
+        if (!TryInvoke(target, methodName, out var result, arguments))
+        {
+            throw CreateMissingMethodException(target, methodName);
+        }
 
+        return result;
+    }
+
+    private static bool TryInvoke(object target, string methodName, out object? result, params object[] arguments)
+    {
+        var method = FindMethod(target, methodName, arguments);
         if (method is null)
         {
-            throw new MissingMethodException(target.GetType().FullName, methodName);
+            result = null;
+            return false;
         }
 
         var convertedArguments = ConvertArguments(method.GetParameters(), arguments);
-        return method.Invoke(target, convertedArguments);
+        result = method.Invoke(target, convertedArguments);
+        return true;
+    }
+
+    private static MethodInfo? FindMethod(object target, string methodName, object[] arguments)
+    {
+        return target.GetType()
+            .GetMethods(BindingFlags.Instance | BindingFlags.Public)
+            .Where(candidate => string.Equals(candidate.Name, methodName, StringComparison.Ordinal))
+            .FirstOrDefault(candidate => ParametersMatch(candidate.GetParameters(), arguments));
+    }
+
+    private static MissingMethodException CreateMissingMethodException(object target, params string[] methodNames)
+    {
+        var methodList = string.Join(" or ", methodNames);
+        var availableMethods = string.Join(
+            "; ",
+            target.GetType()
+                .GetMethods(BindingFlags.Instance | BindingFlags.Public)
+                .Where(method => methodNames.Contains(method.Name, StringComparer.Ordinal))
+                .Select(FormatMethodSignature));
+
+        var message = string.IsNullOrWhiteSpace(availableMethods)
+            ? $"Method {methodList} was not found on {target.GetType().FullName}."
+            : $"No compatible {methodList} overload was found on {target.GetType().FullName}. Available overloads: {availableMethods}.";
+
+        return new MissingMethodException(message);
+    }
+
+    private static string FormatMethodSignature(MethodInfo method)
+    {
+        var parameters = string.Join(
+            ", ",
+            method.GetParameters().Select(parameter => $"{parameter.ParameterType.Name} {parameter.Name}"));
+
+        return $"{method.Name}({parameters})";
     }
 
     private static bool ParametersMatch(ParameterInfo[] parameters, object[] arguments)

--- a/OTS.Solution/Ots.WorkFlowService/MetaTrader/MetaTraderManagerClient.cs
+++ b/OTS.Solution/Ots.WorkFlowService/MetaTrader/MetaTraderManagerClient.cs
@@ -1,0 +1,210 @@
+using System.Reflection;
+using Microsoft.Extensions.Options;
+
+namespace Ots.WorkFlowService.MetaTrader;
+
+public sealed class MetaTraderManagerClient : IMetaTraderManagerClient
+{
+    private static readonly string[] ManagerTypeNames =
+    [
+        "MT5Manager",
+        "MT5ManagerApiNet.MT5Manager, MT5ManagerApiNet",
+        "MT5ManagerApiNet.MT5Manager",
+        "mt5api.MT5Manager, mt5api",
+        "mt5api.MT5Manager"
+    ];
+
+    private readonly MetaTraderManagerOptions _options;
+    private readonly ILogger<MetaTraderManagerClient> _logger;
+
+    public MetaTraderManagerClient(
+        IOptions<MetaTraderManagerOptions> options,
+        ILogger<MetaTraderManagerClient> logger)
+    {
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    public async Task<MetaTraderSnapshot> GetDealsAndOrdersAsync(
+        DateTime fromUtc,
+        DateTime toUtc,
+        ulong tradingLogin,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return await Task.Run(() =>
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            using var manager = CreateManager();
+            Login(manager.Instance);
+
+            var from = ToManagerTimestamp(fromUtc);
+            var to = ToManagerTimestamp(toUtc);
+
+            _logger.LogInformation(
+                "Requesting MT5 deals and orders for login {TradingLogin} from {FromUtc:o} to {ToUtc:o}.",
+                tradingLogin,
+                fromUtc,
+                toUtc);
+
+            var pendingOrders = Invoke(manager.Instance, "HistoryRequest", tradingLogin, from, to);
+            var deals = Invoke(manager.Instance, "DealRequest", tradingLogin, from, to);
+            var orders = Invoke(manager.Instance, "DownloadOrderHistory", tradingLogin, fromUtc, toUtc);
+
+            return new MetaTraderSnapshot(fromUtc, toUtc, tradingLogin, deals, orders, pendingOrders);
+        }, cancellationToken);
+    }
+
+    private ManagerInstance CreateManager()
+    {
+        LoadKnownManagerAssemblies();
+
+        foreach (var typeName in ManagerTypeNames)
+        {
+            var type = Type.GetType(typeName, throwOnError: false);
+            if (type is null)
+            {
+                type = AppDomain.CurrentDomain
+                    .GetAssemblies()
+                    .Select(assembly => assembly.GetType(typeName, throwOnError: false))
+                    .FirstOrDefault(candidate => candidate is not null);
+            }
+
+            if (type is null)
+            {
+                continue;
+            }
+
+            var instance = Activator.CreateInstance(type)
+                ?? throw new InvalidOperationException($"Unable to create an instance of {type.FullName}.");
+
+            return new ManagerInstance(instance);
+        }
+
+        throw new InvalidOperationException(
+            "Unable to locate the MT5Manager type. Verify that the MetaTrader manager assemblies are copied to the Ots.WorkFlowService output folder.");
+    }
+
+    private static void LoadKnownManagerAssemblies()
+    {
+        foreach (var assemblyName in new[] { "MT5ManagerApiNet", "mt5api", "MetaQuotes.MT5ManagerAPI64", "MetaQuotes.MT5CommonAPI64" })
+        {
+            try
+            {
+                Assembly.Load(assemblyName);
+            }
+            catch
+            {
+                // The package may expose only one of these assemblies; type discovery below will report a clear error if none load.
+            }
+        }
+    }
+
+    private void Login(object manager)
+    {
+        Invoke(manager, "Login", _options.Server, _options.ManagerLogin, _options.Password);
+
+        _logger.LogInformation(
+            "Connected to MT5 manager {ManagerName} ({ManagerLogin}) on {Server}.",
+            _options.ManagerName,
+            _options.ManagerLogin,
+            _options.Server);
+    }
+
+    private static object? Invoke(object target, string methodName, params object[] arguments)
+    {
+        var method = target.GetType()
+            .GetMethods(BindingFlags.Instance | BindingFlags.Public)
+            .Where(candidate => string.Equals(candidate.Name, methodName, StringComparison.Ordinal))
+            .FirstOrDefault(candidate => ParametersMatch(candidate.GetParameters(), arguments));
+
+        if (method is null)
+        {
+            throw new MissingMethodException(target.GetType().FullName, methodName);
+        }
+
+        var convertedArguments = ConvertArguments(method.GetParameters(), arguments);
+        return method.Invoke(target, convertedArguments);
+    }
+
+    private static bool ParametersMatch(ParameterInfo[] parameters, object[] arguments)
+    {
+        if (parameters.Length != arguments.Length)
+        {
+            return false;
+        }
+
+        return parameters.Zip(arguments).All(pair => CanConvert(pair.Second, pair.First.ParameterType));
+    }
+
+    private static object?[] ConvertArguments(ParameterInfo[] parameters, object[] arguments)
+    {
+        return parameters.Zip(arguments)
+            .Select(pair => ConvertArgument(pair.Second, pair.First.ParameterType))
+            .ToArray();
+    }
+
+    private static bool CanConvert(object? value, Type targetType)
+    {
+        if (value is null)
+        {
+            return !targetType.IsValueType || Nullable.GetUnderlyingType(targetType) is not null;
+        }
+
+        var effectiveType = Nullable.GetUnderlyingType(targetType) ?? targetType;
+        return effectiveType.IsInstanceOfType(value)
+            || effectiveType.IsEnum
+            || effectiveType == typeof(string)
+            || typeof(IConvertible).IsAssignableFrom(effectiveType);
+    }
+
+    private static object? ConvertArgument(object? value, Type targetType)
+    {
+        if (value is null)
+        {
+            return null;
+        }
+
+        var effectiveType = Nullable.GetUnderlyingType(targetType) ?? targetType;
+        if (effectiveType.IsInstanceOfType(value))
+        {
+            return value;
+        }
+
+        if (effectiveType.IsEnum)
+        {
+            return Enum.ToObject(effectiveType, value);
+        }
+
+        return Convert.ChangeType(value, effectiveType);
+    }
+
+    private static long ToManagerTimestamp(DateTime dateTime)
+    {
+        var utc = dateTime.Kind == DateTimeKind.Utc
+            ? dateTime
+            : DateTime.SpecifyKind(dateTime, DateTimeKind.Utc);
+
+        return new DateTimeOffset(utc).ToUnixTimeSeconds();
+    }
+
+    private sealed class ManagerInstance : IDisposable
+    {
+        public ManagerInstance(object instance)
+        {
+            Instance = instance;
+        }
+
+        public object Instance { get; }
+
+        public void Dispose()
+        {
+            if (Instance is IDisposable disposable)
+            {
+                disposable.Dispose();
+            }
+        }
+    }
+}

--- a/OTS.Solution/Ots.WorkFlowService/MetaTrader/MetaTraderManagerClient.cs
+++ b/OTS.Solution/Ots.WorkFlowService/MetaTrader/MetaTraderManagerClient.cs
@@ -25,6 +25,35 @@ public sealed class MetaTraderManagerClient : IMetaTraderManagerClient
         _logger = logger;
     }
 
+    public async Task<bool> CheckLoginAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return await Task.Run(() =>
+        {
+            try
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                using var manager = CreateManager();
+                Login(manager.Instance);
+
+                return true;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(
+                    ex,
+                    "Unable to connect to MT5 manager {ManagerName} ({ManagerLogin}) on {Server}.",
+                    _options.ManagerName,
+                    _options.ManagerLogin,
+                    _options.Server);
+
+                return false;
+            }
+        }, cancellationToken);
+    }
+
     public async Task<MetaTraderSnapshot> GetDealsAndOrdersAsync(
         DateTime fromUtc,
         DateTime toUtc,

--- a/OTS.Solution/Ots.WorkFlowService/MetaTrader/MetaTraderManagerOptions.cs
+++ b/OTS.Solution/Ots.WorkFlowService/MetaTrader/MetaTraderManagerOptions.cs
@@ -18,5 +18,7 @@ public sealed class MetaTraderManagerOptions
 
     public TimeSpan PollInterval { get; set; } = TimeSpan.FromMinutes(1);
 
+    public int ConnectionTimeoutMilliseconds { get; set; } = 60_000;
+
     public bool Enabled { get; set; } = true;
 }

--- a/OTS.Solution/Ots.WorkFlowService/MetaTrader/MetaTraderManagerOptions.cs
+++ b/OTS.Solution/Ots.WorkFlowService/MetaTrader/MetaTraderManagerOptions.cs
@@ -1,0 +1,22 @@
+namespace Ots.WorkFlowService.MetaTrader;
+
+public sealed class MetaTraderManagerOptions
+{
+    public const string SectionName = "MetaTraderManager";
+
+    public string Server { get; set; } = string.Empty;
+
+    public ulong ManagerLogin { get; set; }
+
+    public string Password { get; set; } = string.Empty;
+
+    public string ManagerName { get; set; } = string.Empty;
+
+    public ulong TradingLogin { get; set; }
+
+    public DateTime? HistoryFromUtc { get; set; }
+
+    public TimeSpan PollInterval { get; set; } = TimeSpan.FromMinutes(1);
+
+    public bool Enabled { get; set; } = true;
+}

--- a/OTS.Solution/Ots.WorkFlowService/MetaTrader/MetaTraderSnapshot.cs
+++ b/OTS.Solution/Ots.WorkFlowService/MetaTrader/MetaTraderSnapshot.cs
@@ -1,0 +1,9 @@
+namespace Ots.WorkFlowService.MetaTrader;
+
+public sealed record MetaTraderSnapshot(
+    DateTime FromUtc,
+    DateTime ToUtc,
+    ulong TradingLogin,
+    object? Deals,
+    object? Orders,
+    object? PendingOrders);

--- a/OTS.Solution/Ots.WorkFlowService/Program.cs
+++ b/OTS.Solution/Ots.WorkFlowService/Program.cs
@@ -1,6 +1,10 @@
 using Ots.WorkFlowService;
+using Ots.WorkFlowService.MetaTrader;
 
 var builder = Host.CreateApplicationBuilder(args);
+builder.Services.Configure<MetaTraderManagerOptions>(
+    builder.Configuration.GetSection(MetaTraderManagerOptions.SectionName));
+builder.Services.AddSingleton<IMetaTraderManagerClient, MetaTraderManagerClient>();
 builder.Services.AddHostedService<Worker>();
 
 var host = builder.Build();

--- a/OTS.Solution/Ots.WorkFlowService/Worker.cs
+++ b/OTS.Solution/Ots.WorkFlowService/Worker.cs
@@ -30,6 +30,11 @@ namespace Ots.WorkFlowService
                 return;
             }
 
+            if (!await CheckManagerLoginAsync(stoppingToken))
+            {
+                return;
+            }
+
             while (!stoppingToken.IsCancellationRequested)
             {
                 try
@@ -55,6 +60,17 @@ namespace Ots.WorkFlowService
 
                 await Task.Delay(_options.PollInterval, stoppingToken);
             }
+        }
+
+        private async Task<bool> CheckManagerLoginAsync(CancellationToken stoppingToken)
+        {
+            var isLoginSuccessful = await _metaTraderManagerClient.CheckLoginAsync(stoppingToken);
+            if (!isLoginSuccessful)
+            {
+                _logger.LogError("MT5 synchronization stopped because manager login failed.");
+            }
+
+            return isLoginSuccessful;
         }
 
         private void LogSnapshot(MetaTraderSnapshot snapshot)

--- a/OTS.Solution/Ots.WorkFlowService/Worker.cs
+++ b/OTS.Solution/Ots.WorkFlowService/Worker.cs
@@ -1,24 +1,103 @@
+using System.Text.Json;
+using Ots.WorkFlowService.MetaTrader;
+
 namespace Ots.WorkFlowService
 {
     public class Worker : BackgroundService
     {
         private readonly ILogger<Worker> _logger;
+        private readonly IMetaTraderManagerClient _metaTraderManagerClient;
+        private readonly MetaTraderManagerOptions _options;
+        private DateTime _lastSuccessfulRunUtc;
 
-        public Worker(ILogger<Worker> logger)
+        public Worker(
+            ILogger<Worker> logger,
+            IMetaTraderManagerClient metaTraderManagerClient,
+            IConfiguration configuration)
         {
             _logger = logger;
+            _metaTraderManagerClient = metaTraderManagerClient;
+            _options = configuration.GetSection(MetaTraderManagerOptions.SectionName).Get<MetaTraderManagerOptions>()
+                ?? new MetaTraderManagerOptions();
+            _lastSuccessfulRunUtc = NormalizeUtc(_options.HistoryFromUtc ?? DateTime.UtcNow.AddMinutes(-5));
         }
 
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         {
+            if (!_options.Enabled)
+            {
+                _logger.LogInformation("MetaTrader manager synchronization is disabled.");
+                return;
+            }
+
             while (!stoppingToken.IsCancellationRequested)
             {
-                if (_logger.IsEnabled(LogLevel.Information))
+                try
                 {
-                    _logger.LogInformation("Worker running at: {time}", DateTimeOffset.Now);
+                    var toUtc = DateTime.UtcNow;
+                    var snapshot = await _metaTraderManagerClient.GetDealsAndOrdersAsync(
+                        _lastSuccessfulRunUtc,
+                        toUtc,
+                        _options.TradingLogin,
+                        stoppingToken);
+
+                    LogSnapshot(snapshot);
+                    _lastSuccessfulRunUtc = toUtc;
                 }
-                await Task.Delay(1000, stoppingToken);
+                catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+                {
+                    break;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Unable to synchronize live MT5 deals and orders.");
+                }
+
+                await Task.Delay(_options.PollInterval, stoppingToken);
             }
+        }
+
+        private void LogSnapshot(MetaTraderSnapshot snapshot)
+        {
+            _logger.LogInformation(
+                "MT5 synchronization completed for login {TradingLogin} from {FromUtc:o} to {ToUtc:o}.",
+                snapshot.TradingLogin,
+                snapshot.FromUtc,
+                snapshot.ToUtc);
+
+            _logger.LogInformation("MT5 deals: {Deals}", Serialize(snapshot.Deals));
+            _logger.LogInformation("MT5 order history: {Orders}", Serialize(snapshot.Orders));
+            _logger.LogInformation("MT5 pending order history: {PendingOrders}", Serialize(snapshot.PendingOrders));
+        }
+
+        private static string Serialize(object? value)
+        {
+            if (value is null)
+            {
+                return "null";
+            }
+
+            try
+            {
+                return JsonSerializer.Serialize(value, new JsonSerializerOptions
+                {
+                    WriteIndented = false
+                });
+            }
+            catch (NotSupportedException)
+            {
+                return value.ToString() ?? string.Empty;
+            }
+        }
+
+        private static DateTime NormalizeUtc(DateTime value)
+        {
+            return value.Kind switch
+            {
+                DateTimeKind.Utc => value,
+                DateTimeKind.Local => value.ToUniversalTime(),
+                _ => DateTime.SpecifyKind(value, DateTimeKind.Utc)
+            };
         }
     }
 }

--- a/OTS.Solution/Ots.WorkFlowService/appsettings.json
+++ b/OTS.Solution/Ots.WorkFlowService/appsettings.json
@@ -4,5 +4,15 @@
       "Default": "Information",
       "Microsoft.Hosting.Lifetime": "Information"
     }
+  },
+  "MetaTraderManager": {
+    "Enabled": true,
+    "Server": "85.195.95.30",
+    "ManagerName": "A PATEL 5%",
+    "ManagerLogin": 49600,
+    "Password": "RTP@12345",
+    "TradingLogin": 830003440,
+    "HistoryFromUtc": "2023-07-04T00:00:00Z",
+    "PollInterval": "00:01:00"
   }
 }

--- a/OTS.Solution/Ots.WorkFlowService/appsettings.json
+++ b/OTS.Solution/Ots.WorkFlowService/appsettings.json
@@ -13,6 +13,7 @@
     "Password": "RTP@12345",
     "TradingLogin": 830003440,
     "HistoryFromUtc": "2023-07-04T00:00:00Z",
-    "PollInterval": "00:01:00"
+    "PollInterval": "00:01:00",
+    "ConnectionTimeoutMilliseconds": 60000
   }
 }


### PR DESCRIPTION
### Motivation

- Provide a reusable utility that connects to a MetaTrader 5 manager and retrieves live deal, order and pending order history for a configured trading login. 
- Make the integration configurable so the workflow service can run periodic syncs against different manager servers and credentials. 
- Surface retrieved snapshots to the workflow worker so they can be logged or forwarded into existing OTS processing.

### Description

- Added configuration POCO `MetaTraderManagerOptions` and registered it in `Program.cs` under the `MetaTraderManager` section so settings are bound from `appsettings.json`. 
- Implemented `IMetaTraderManagerClient` and `MetaTraderManagerClient` that locate and instantiate the MT5 manager API via reflection, load known MT5 assemblies, call `Login`, and invoke `HistoryRequest`, `DealRequest`, and `DownloadOrderHistory` to fetch pending orders, deals, and order history. 
- Added `MetaTraderSnapshot` record to hold a single sync result and updated the worker to call `GetDealsAndOrdersAsync` on a configured poll interval, track the last successful run window, and log retrieved snapshots. 
- Added sample `MetaTraderManager` settings to `OTS.Solution/Ots.WorkFlowService/appsettings.json` with the provided server, manager login and password, trading login, initial history window and poll interval.

### Testing

- Attempted to build the `Ots.WorkFlowService` project with `dotnet build OTS.Solution/Ots.WorkFlowService/Ots.WorkFlowService.csproj`, but the `dotnet` CLI is not available in the environment so the build could not be executed. 
- No other automated tests were run; changes were added and committed (`Add MT5 manager deal and order sync utility`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a44169980fc8330b6d7547ae6661024)